### PR TITLE
Miscellaneous Patches

### DIFF
--- a/core/client.py
+++ b/core/client.py
@@ -19,7 +19,8 @@ class Client(object):
         model.train()
 
         trained_unique_samples = min(len(client_data.dataset), conf.local_steps * conf.batch_size)
-        global_model = [param.data.clone() for param in model.parameters()]
+        if conf.gradient_policy == 'prox':
+            global_model = [param.data.clone() for param in model.parameters()]
 
         if conf.task == "detection":
             lr = conf.learning_rate

--- a/core/evals/manager.py
+++ b/core/evals/manager.py
@@ -78,18 +78,14 @@ def process_cmd(yaml_file):
         running_vms.add(worker)
         print(f"Starting workers on {worker} ...")
 
-        for gpu_idx in range(gpu[0]):
-            if worker == ps_ip:
-                cuda_id = gpu_idx + 1
-            else:
-                cuda_id = gpu_idx
-                
-            worker_cmd = f" python {yaml_conf['exp_path']}/{yaml_conf['executor_entry']} {conf_script} --this_rank={rank_id} --learner={learner_conf} --cuda_device=cuda:{cuda_id} "
-            rank_id += 1
+        for cuda_id in range(len(gpu)):
+            for _  in range(gpu[cuda_id]):
+                worker_cmd = f" python {yaml_conf['exp_path']}/{yaml_conf['executor_entry']} {conf_script} --this_rank={rank_id} --learner={learner_conf} --cuda_device=cuda:{cuda_id} "
+                rank_id += 1
 
-            with open(f"{job_name}_logging", 'a') as fout:
-                subprocess.Popen(f'ssh {submit_user}{worker} "{setup_cmd} {worker_cmd}"',
-                                shell=True, stdout=fout, stderr=fout)
+                with open(f"{job_name}_logging", 'a') as fout:
+                    subprocess.Popen(f'ssh {submit_user}{worker} "{setup_cmd} {worker_cmd}"',
+                                    shell=True, stdout=fout, stderr=fout)
 
     # dump the address of running workers
     current_path = os.path.dirname(os.path.abspath(__file__))

--- a/core/evals/manager.py
+++ b/core/evals/manager.py
@@ -78,14 +78,18 @@ def process_cmd(yaml_file):
         running_vms.add(worker)
         print(f"Starting workers on {worker} ...")
 
-        for cuda_id in range(len(gpu)):
-            for _  in range(gpu[cuda_id]):
-                worker_cmd = f" python {yaml_conf['exp_path']}/{yaml_conf['executor_entry']} {conf_script} --this_rank={rank_id} --learner={learner_conf} --cuda_device=cuda:{cuda_id} "
-                rank_id += 1
+        for gpu_idx in range(gpu[0]):
+            if worker == ps_ip:
+                cuda_id = gpu_idx + 1
+            else:
+                cuda_id = gpu_idx
+                
+            worker_cmd = f" python {yaml_conf['exp_path']}/{yaml_conf['executor_entry']} {conf_script} --this_rank={rank_id} --learner={learner_conf} --cuda_device=cuda:{cuda_id} "
+            rank_id += 1
 
-                with open(f"{job_name}_logging", 'a') as fout:
-                    subprocess.Popen(f'ssh {submit_user}{worker} "{setup_cmd} {worker_cmd}"',
-                                    shell=True, stdout=fout, stderr=fout)
+            with open(f"{job_name}_logging", 'a') as fout:
+                subprocess.Popen(f'ssh {submit_user}{worker} "{setup_cmd} {worker_cmd}"',
+                                shell=True, stdout=fout, stderr=fout)
 
     # dump the address of running workers
     current_path = os.path.dirname(os.path.abspath(__file__))

--- a/core/evals/shutdown.py
+++ b/core/evals/shutdown.py
@@ -5,8 +5,8 @@ import argparse
 job_name = sys.argv[1]
 
 if job_name == 'all':
-    os.system("ps -ef | grep python | grep Kuiper > kuiper_running_temp")
+    os.system("ps -ef | grep python | grep FedScale > fedscale_running_temp")
 else:
-    os.system("ps -ef | grep python | grep job_name={} > kuiper_running_temp".format(job_name))
-[os.system("kill -9 "+str(l.split()[1])) for l in open("kuiper_running_temp").readlines()]
-os.system("rm kuiper_running_temp")
+    os.system("ps -ef | grep python | grep job_name={} > fedscale_running_temp".format(job_name))
+[os.system("kill -9 "+str(l.split()[1]) + " 1>/dev/null 2>&1") for l in open("fedscale_running_temp").readlines()]
+os.system("rm fedscale_running_temp")

--- a/core/utils/nlp.py
+++ b/core/utils/nlp.py
@@ -68,7 +68,6 @@ class TextDataset(Dataset):
             files = [os.path.join(file_path, x) for x in sorted(files)]
             
             start_time = time.time()
-                        start_time = time.time()
             for idx, file in enumerate(files):
                 try:
                     with open(file, encoding="utf-8", errors='ignore') as f:


### PR DESCRIPTION
These are the places I think worth improving during my practice, which you may be also interested in:

1. For `core/client.py`: As the local variable `global_model` is only used when the gradient policy is something like `FedProx` (as indicated in [Line 152](https://github.com/SymbioticLab/FedScale/blob/97820a1006c83a1bc9308888498dfc32bd50956d/core/client.py#L152)), I am proposing not to introduce it when it is not necessary for sake of efficiency.
2. For `core/evals/manager.py`: (1) As the convention of indicating the number of GPUs used in each worker during configuration has been updated recently (as exemplified [here](https://github.com/SymbioticLab/FedScale/blob/97820a1006c83a1bc9308888498dfc32bd50956d/core/evals/configs/openimage/conf.yml#L11)), I suspect that the original parsing logic ([Line 81-82](https://github.com/SymbioticLab/FedScale/blob/97820a1006c83a1bc9308888498dfc32bd50956d/core/evals/manager.py#L81) in `core/evals/manager.py`) has been broken. I hereby change it to accommodate the latest convention of consistency. (2) Moreover, as I observe in `core/evals/aggregator.py`, the aggregator tends to use the first available GPU of the parameter server, which should be `cuda:0`. On the other hand, if a worker is co-located with the aggregator, the original program does not seem to force the worker to use different GPUs. In this case, in the parameter server `cuda:0` will be used by both the worker and the aggregator, while there exists another GPU that remains idle.
3. For `core/evals/shutdown.py`: (1) Change the occurrence of `Kuiper` to `FedScale` for consistency. (2) Append ` 1>/dev/null 2>&1` to kill command for muting messages like `sh: line 0: kill: (xxxxx) - No such process` where `xxxxx` is the process id of the previous executed `ps -ef | grep python | grep FedScale > fedscale_running_temp`.