### PR TITLE
Fixing Multiprocessing-Related Issues

### DIFF
--- a/core/aggregator.py
+++ b/core/aggregator.py
@@ -452,6 +452,7 @@ class Aggregator(object):
                 elif event_msg == 'stop':
                     self.broadcast_msg(send_msg)
                     self.stop()
+                    break
 
                 elif event_msg == 'report_executor_info':
                     self.broadcast_msg(send_msg)

--- a/core/executor.py
+++ b/core/executor.py
@@ -291,7 +291,7 @@ class Executor(object):
     def stop(self):
         logging.info(f"Terminating (Executor {self.this_rank}) ...")
 
-        self.control_manager.shutdown()
+        #self.control_manager.shutdown()
 
 
 if __name__ == "__main__":

--- a/core/utils/divide_data.py
+++ b/core/utils/divide_data.py
@@ -120,11 +120,14 @@ def select_dataset(rank, partition, batch_size, isTest=False, collate_fn=None):
     """Load data given client Id"""
     partition = partition.use(rank - 1, isTest)
     dropLast = False if isTest else True
-    time_out = 60
     num_loaders = min(int(len(partition)/args.batch_size/2), args.num_loaders)
+    if num_loaders == 0:
+        time_out == 0
+    else:
+        time_out = 60
 
     if collate_fn is not None:
-        return DataLoader(partition, batch_size=batch_size, shuffle=True, pin_memory=True, timeout=time_out, num_workers=args.num_loaders, drop_last=dropLast, collate_fn=collate_fn)
-    return DataLoader(partition, batch_size=batch_size, shuffle=True, pin_memory=True, timeout=time_out, num_workers=args.num_loaders, drop_last=dropLast)
+        return DataLoader(partition, batch_size=batch_size, shuffle=True, pin_memory=True, timeout=time_out, num_workers=num_loaders, drop_last=dropLast, collate_fn=collate_fn)
+    return DataLoader(partition, batch_size=batch_size, shuffle=True, pin_memory=True, timeout=time_out, num_workers=num_loaders, drop_last=dropLast)
 
 

--- a/core/utils/divide_data.py
+++ b/core/utils/divide_data.py
@@ -122,7 +122,7 @@ def select_dataset(rank, partition, batch_size, isTest=False, collate_fn=None):
     dropLast = False if isTest else True
     num_loaders = min(int(len(partition)/args.batch_size/2), args.num_loaders)
     if num_loaders == 0:
-        time_out == 0
+        time_out = 0
     else:
         time_out = 60
 


### PR DESCRIPTION
In the lastest [commit](https://github.com/SymbioticLab/FedScale/commit/45072d3f6e154cc12e0b1af556cd10495a540ac0) of FedScale, when the training process terminates due to reaching the epoch limit, two types of exception messages will be printed in the log:

1. AttributeError (repeating `x` times where `x` is the number of spawned executors):

```
Traceback (most recent call last):
  File ".../FedScale/core/executor.py", line 299, in <module>
    executor.run()
  File ".../FedScale/core/executor.py", line 131, in run
    self.event_monitor()
  File ".../FedScale/core/executor.py", line 282, in event_monitor
    self.stop()
  File ".../FedScale/core/executor.py", line 294, in stop
    self.control_manager.shutdown()
AttributeError: 'BaseManager' object has no attribute 'shutdown'
```

According to [multiprocessing's document](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.managers.BaseManager.shutdown), the method is **only available if start() has been used to start the server process**. So I think that the termination of BaseManager should merely be done at `core/aggregator.py`, which you have already implemented at [Line 504](https://github.com/SymbioticLab/FedScale/blob/45072d3f6e154cc12e0b1af556cd10495a540ac0/core/aggregator.py#L504), but not at `core/executor.py`.

2. EOFError (once):

```
Traceback (most recent call last):
  File ".../FedScale/core/aggregator.py", line 508, in <module>
    aggregator.run()
  File ".../FedScale/core/aggregator.py", line 231, in run
    self.event_monitor()
  File ".../FedScale/core/aggregator.py", line 462, in event_monitor
    elif not self.client_event_queue.empty():
  File "<string>", line 2, in empty
  File ".../anaconda3/envs/fedscale/lib/python3.6/multiprocessing/managers.py", line 757, in _callmethod
    kind, result = conn.recv()
  File ".../anaconda3/envs/fedscale/lib/python3.6/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File ".../anaconda3/envs/fedscale/lib/python3.6/multiprocessing/connection.py", line 407, in _recv_bytes
    buf = self._recv(4)
  File ".../anaconda3/envs/fedscale/lib/python3.6/multiprocessing/connection.py", line 383, in _recv
    raise EOFError
EOFError
```

Again, according to the aforementioned [document](https://docs.python.org/3/library/multiprocessing.html#connection-objects), **recv() raises EOFError if there is nothing left to receive and the other end was closed**. This is actually the case, as the BaseManager is shut down (as a result of [Line 454](https://github.com/SymbioticLab/FedScale/blob/45072d3f6e154cc12e0b1af556cd10495a540ac0/core/aggregator.py#L454)) prior to the last calling of `elif not self.client_event_queue.empty():` ([Line 462](https://github.com/SymbioticLab/FedScale/blob/45072d3f6e154cc12e0b1af556cd10495a540ac0/core/aggregator.py#L462)). So I suspect that a `break` clause immediately after `self.stop()` is missing.

---

In addition, I found that **FedScale did not use the `num_loaders` calculated in [Line 124](https://github.com/SymbioticLab/FedScale/blob/45072d3f6e154cc12e0b1af556cd10495a540ac0/core/utils/divide_data.py#L124), File `core/utils/divide_data`**. This actually brought me `[Errno 12] Cannot allocate memory` when loading data. Specifically, it turnt out that the newly calculated `num_loaders` was `0`, while I was still using what was indicated by `args.num_loaders` (4 by default). Changing `args.num_loaders` to `num_loaders` works well for me. By the way, it is implied by the [implementation of torch's dataloader](https://github.com/pytorch/pytorch/blob/bfe03120eebc8b2b7c256d08887a782de9b6177c/torch/utils/data/dataloader.py#L553) that the `timeout` argument should be set to `0` whenever `num_workers`(a.k.a. num_loaders in your context) equals to 0. I hereby also reframe the assignment logic for `timeout`. Please also consider merging this change.