### PR TITLE
Miscellaneous Update

### DIFF
--- a/core/aggregator.py
+++ b/core/aggregator.py
@@ -263,7 +263,8 @@ class Aggregator(object):
         # Format:
         #       -results = {'clientId':clientId, 'update_weight': model_param, 'moving_loss': epoch_train_loss,
         #       'trained_size': count, 'wall_duration': time_cost, 'success': is_success 'utility': utility}
-        self.client_training_results.append(results)
+        if self.args.gradient_policy in ['qfedavg']:
+            self.client_training_results.append(results)
 
         # Feed metrics to client sampler
         self.stats_util_accumulator.append(results['utility'])

--- a/core/client_manager.py
+++ b/core/client_manager.py
@@ -114,8 +114,6 @@ class clientManager(object):
 
             init_id = max(0, min(int(math.floor(self.rng.random() * lenPossible)), lenPossible - 1))
 
-        return init_id
-
     def getUniqueId(self, hostId, clientId):
         return str(clientId)
         #return (str(hostId) + '_' + str(clientId))

--- a/core/executor.py
+++ b/core/executor.py
@@ -134,10 +134,6 @@ class Executor(object):
         executor_info = self.report_executor_info_handler()
         self.push_msg_to_server('report_executor_info', executor_info)
 
-    def start_event(self):
-        executor_info = self.report_executor_info_handler()
-        self.push_msg_to_server('report_executor_info', executor_info)
-
 
     def push_msg_to_server(self, event, results):
         self.client_event_queue.put({'return': results, 'event': event, 'executorId': self.this_rank})

--- a/core/executor.py
+++ b/core/executor.py
@@ -38,16 +38,19 @@ class Executor(object):
         self.setup_seed(seed=self.this_rank)
 
         # set up device
-        if self.args.use_cuda and self.device == None:
-            for i in range(torch.cuda.device_count()):
-                try:
-                    self.device = torch.device('cuda:'+str(i))
-                    torch.cuda.set_device(i)
-                    print(torch.rand(1).to(device=self.device))
-                    logging.info(f'End up with cuda device ({self.device})')
-                    break
-                except Exception as e:
-                    assert i != torch.cuda.device_count()-1, 'Can not find available GPUs'
+        if self.args.use_cuda:
+            if self.device == None:
+                for i in range(torch.cuda.device_count()):
+                    try:
+                        self.device = torch.device('cuda:'+str(i))
+                        torch.cuda.set_device(i)
+                        print(torch.rand(1).to(device=self.device))
+                        logging.info(f'End up with cuda device ({self.device})')
+                        break
+                    except Exception as e:
+                        assert i != torch.cuda.device_count()-1, 'Can not find available GPUs'
+            else:
+                torch.cuda.set_device(self.device)
 
         self.init_control_communication(self.args.ps_ip, self.args.manager_port)
         self.init_data_communication()


### PR DESCRIPTION
1. `core/aggregator.py`: I think that we should reserve clients' model (and other reported results) only when necessary, e.g., when using qFedAvg. This can help release the main memory pressure at the aggregator as I observed.

2. `core/client_manager.py`: an unreachable line removed.

3. `core/executor.py`: (1) a redundant definition of `start_event()` is discarded, and (2) the setup of the GPU environment at each executor is refined. Originally, when `self.device` is not `None`, we did not have the clause `torch.cuda.set_device(self.device)`. This does not hurt much if one remembers to append `.to(device=self.device)` for every tensors. However, as the default device is `cuda:0`, if one happens to introduce an intermediate tensor that does not have `.to(device=self.device)` appended, the tensor will just be placed at `cuda:0`, which may not be an expected behavior.