### PR TITLE
Fix path mismatch

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -48,7 +48,7 @@ They are close to the settings used in our evaluations. Comments in our example 
 
 
 ***We are working on building the leaderboards for better visualization. So far, all logs will be dumped to ```log_path``` (specified in the config file) on each node. 
-```training_perf``` locates at the master node under this path, and the user can load it with ```pickle``` to check the time-to-accuracy performance. 
+```testing_perf``` locates at the master node under this path, and the user can load it with ```pickle``` to check the time-to-accuracy performance. 
 Meanwhile, the user can check ```/evals/[job_name]_logging``` to see whether the job is moving on.***
 
 

--- a/core/aggregator.py
+++ b/core/aggregator.py
@@ -384,6 +384,9 @@ class Aggregator(object):
                     self.testing_history['perf'][self.epoch]['top_5'], self.testing_history['perf'][self.epoch]['loss'],
                     self.testing_history['perf'][self.epoch]['test_len']))
 
+            # Dump the testing result
+            with open(os.path.join(logDir, 'testing_perf'), 'wb') as fout:
+                pickle.dump(self.testing_history, fout)
 
             self.event_queue.append('start_round')
 

--- a/core/evals/configs/openimage/conf.yml
+++ b/core/evals/configs/openimage/conf.yml
@@ -25,7 +25,7 @@ worker_ips:
 exp_path: $HOME/FedScale/core
 
 # Entry function of executor and aggregator under $exp_path
-executor_entry: examples/poisoning_setting/customized_executor.py
+executor_entry: executor.py
 
 aggregator_entry: aggregator.py
 
@@ -42,8 +42,8 @@ setup_commands:
 # Default parameters are specified in argParser.py, wherein more description of the parameter can be found
 
 job_conf: 
-    - log_path: $HOME/FedScale/core/evals # Path of log files
     - job_name: openimage                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - log_path: $HOME/FedScale/core/evals # Path of log files
     - total_worker: 100                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: openImg                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: $HOME/FedScale/dataset/data/openImg    # Path of the dataset

--- a/core/evals/configs/reddit/conf.yml
+++ b/core/evals/configs/reddit/conf.yml
@@ -40,8 +40,8 @@ setup_commands:
 # Default parameters are specified in argParser.py, wherein more description of the parameter can be found
 
 job_conf: 
-    - log_path: $HOME/FedScale/core/evals # Path of log files
     - job_name: reddit                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - log_path: $HOME/FedScale/core/evals # Path of log files
     - task: nlp
     - total_worker: 100                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: blog                     # Dataset: openImg, google_speech, reddit

--- a/core/evals/configs/speech/conf.yml
+++ b/core/evals/configs/speech/conf.yml
@@ -40,8 +40,8 @@ setup_commands:
 # Default parameters are specified in argParser.py, wherein more description of the parameter can be found
 
 job_conf: 
-    - log_path: $HOME/FedScale/core/evals # Path of log files
     - job_name: google_speech                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - log_path: $HOME/FedScale/core/evals # Path of log files
     - task: speech
     - total_worker: 100                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: google_speech                     # Dataset: openImg, google_speech, stackoverflow
@@ -61,5 +61,4 @@ job_conf:
     - learning_rate: 0.05
     - batch_size: 20
     - test_bsz: 20
-
 

--- a/core/evals/manager.py
+++ b/core/evals/manager.py
@@ -84,6 +84,7 @@ def process_cmd(yaml_file):
                 rank_id += 1
 
                 with open(f"{job_name}_logging", 'a') as fout:
+                    time.sleep(2)
                     subprocess.Popen(f'ssh {submit_user}{worker} "{setup_cmd} {worker_cmd}"',
                                     shell=True, stdout=fout, stderr=fout)
 

--- a/core/fl_aggregator_libs.py
+++ b/core/fl_aggregator_libs.py
@@ -1,7 +1,7 @@
 # package for aggregator
 from fllibs import *
 
-logDir = os.path.join(os.environ['HOME'], "models", args.model, args.time_stamp, 'aggregator')
+logDir = os.path.join(args.log_path, "logs", args.job_name, args.time_stamp, 'aggregator')
 logFile = os.path.join(logDir, 'log')
 
 def init_logging():

--- a/core/fl_client_libs.py
+++ b/core/fl_client_libs.py
@@ -3,8 +3,8 @@ from fllibs import *
 from torch.nn.utils.rnn import pad_sequence
 import os
 
-logDir = os.path.join(os.environ['HOME'], "models", args.model, args.time_stamp, 'executor')
-logFile = os.path.join(logDir, 'log_'+str(args.this_rank))
+logDir = os.path.join(args.log_path, "logs", args.job_name, args.time_stamp, 'executor')
+logFile = os.path.join(logDir, 'log')
 
 def init_logging():
     if not os.path.isdir(logDir):
@@ -75,3 +75,4 @@ def voice_collate_fn(batch):
 
 # initiate the log path, and executor ips
 initiate_client_setting()
+


### PR DESCRIPTION
The previous log path is incorrect. Now, all the logs are under ```$log_path/logs/$job_name/time_stamp/```.