### PR TITLE
Fix data partition error. Do not remove the last data.

### DIFF
--- a/core/utils/divide_data.py
+++ b/core/utils/divide_data.py
@@ -104,7 +104,7 @@ class DataPartitioner(object):
     def use(self, partition, istest):
         resultIndex = self.partitions[partition]
 
-        exeuteLength = -1 if not istest else int(len(resultIndex) * self.args.test_ratio)
+        exeuteLength = len(resultIndex) if not istest else int(len(resultIndex) * self.args.test_ratio)
         resultIndex = resultIndex[:exeuteLength]
         self.rng.shuffle(resultIndex)
 


### PR DESCRIPTION
When using data for training, the last data should not be removed.