### PR TITLE
support customized max_message_length for gRPC

### DIFF
--- a/core/aggregator.py
+++ b/core/aggregator.py
@@ -107,7 +107,7 @@ class Aggregator(object):
         # Create communication channel between aggregator and worker
         # This channel serves control messages
         logging.info(f"Initiating control plane communication ...")
-        self.executors = ExecutorConnections(self.args.executor_configs, self.args.base_port)
+        self.executors = ExecutorConnections(self.args.executor_configs, self.args.base_port, self.args.max_message_length)
 
 
     def init_data_communication(self):

--- a/core/argParser.py
+++ b/core/argParser.py
@@ -26,6 +26,7 @@ parser.add_argument('--exploration_decay', type=float, default=0.98)
 parser.add_argument('--sample_window', type=float, default=5.0)
 parser.add_argument('--device_avail_file', type=str, default=None)
 parser.add_argument('--clock_factor', type=float, default=1.0, help="Refactor the clock time given the profile")
+parser.add_argument('--max_message_length', type=int, default=50000000)
 
 
 # The configuration of model and dataset

--- a/core/communication/channelcontext.py
+++ b/core/communication/channelcontext.py
@@ -5,7 +5,6 @@ import job_api_pb2
 
 class ExecutorConnections(object):
     """"Helps aggregator manage its grpc connection with executors."""
-    MAX_MESSAGE_LENGTH = 50000000
 
     class _ExecutorContext(object):
         def __init__(self, executorId):
@@ -14,7 +13,8 @@ class ExecutorConnections(object):
             self.channel = None
             self.stub = None
 
-    def __init__(self, config, base_port=50000):
+    def __init__(self, config, base_port=50000, max_message_length=50000000):
+        self.MAX_MESSAGE_LENGTH = max_message_length
         self.executors = {}
         self.base_port = base_port
 

--- a/core/evals/configs/cpu-cifar/conf.yml
+++ b/core/evals/configs/cpu-cifar/conf.yml
@@ -25,6 +25,8 @@ auth:
 setup_commands:
     - source $HOME/anaconda3/bin/activate fedscale
 
+max_message_length: 50000000 # bytes
+
 # ========== Additional job configuration ========== 
 # Default parameters are specified in argParser.py, wherein more description of the parameter can be found
 

--- a/core/evals/manager.py
+++ b/core/evals/manager.py
@@ -17,6 +17,9 @@ def process_cmd(yaml_file,local = False):
     yaml_conf = load_yaml_conf(yaml_file)
 
     ps_ip = yaml_conf['ps_ip']
+    max_message_length = 50000000
+    if 'max_message_length' in yaml_conf:
+        max_message_length = yaml_conf['max_message_length']
     worker_ips, total_gpus = [], []
     cmd_script_list = []
 
@@ -37,6 +40,7 @@ def process_cmd(yaml_file,local = False):
                 'ps_port':random.randint(1000, 50000),
                 'manager_port':random.randint(1000, 50000),
                 'base_port': random.randint(8000, 50000),
+                'max_message_length': max_message_length,
                 }
 
     for conf in yaml_conf['job_conf']:


### PR DESCRIPTION
add max_message_length to arguments and config file so that we can adjust the length of message of communication in order to e.g. train a larger model