### PR TITLE
Refactor communication protocols

### DIFF
--- a/evals/configs/cpu-cifar/conf.yml
+++ b/evals/configs/cpu-cifar/conf.yml
@@ -30,13 +30,13 @@ setup_commands:
 
 job_conf: 
     - job_name: cifar                   # Generate logs under this folder: log_path/job_name/time_stamp
-    - log_path: $HOME/FedScale/fedscale/logs # Path of log files
+    - log_path: $HOME/FedScale/evals # Path of log files
     - total_worker: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: $HOME/FedScale/dataset/data/    # Path of the dataset
     - model: shufflenet_v2_x2_0                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 5                     # How many rounds to run a testing on the testing set
-    - epochs: 200                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - rounds: 600                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples
     - num_loaders: 2
     - local_steps: 20

--- a/evals/configs/openimage/conf.yml
+++ b/evals/configs/openimage/conf.yml
@@ -22,7 +22,7 @@ worker_ips:
     - 10.0.0.13:[4]
     - 10.0.0.14:[4]
 
-exp_path: $HOME/FedScale/core
+exp_path: $HOME/FedScale/fedscale/core
 
 # Entry function of executor and aggregator under $exp_path
 executor_entry: executor.py
@@ -43,7 +43,7 @@ setup_commands:
 
 job_conf: 
     - job_name: openimage                   # Generate logs under this folder: log_path/job_name/time_stamp
-    - log_path: $HOME/FedScale/core/evals # Path of log files
+    - log_path: $HOME/FedScale/evals # Path of log files
     - total_worker: 100                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: openImg                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: $HOME/FedScale/dataset/data/openImg    # Path of the dataset

--- a/evals/configs/others/dry_run.yml
+++ b/evals/configs/others/dry_run.yml
@@ -9,11 +9,12 @@ ps_ip: 10.0.0.1
 # E.g., master node has 4 available processes, then 1 for the ps, and worker should be set to: worker:3
 worker_ips: 
     - 10.0.0.1:[2] # worker_ip: [(# processes on gpu) for gpu in available_gpus] eg. 10.0.0.2:[4,4,4,4] This node has 4 gpus, each gpu has 4 processes. 
+    - 10.0.0.2:[2]
 
-exp_path: $HOME/FedScale/core
+exp_path: $HOME/FedScale/fedscale/core
 
 # Entry function of executor and aggregator under $exp_path
-executor_entry: ./examples/dry_run/customized_executor.py
+executor_entry: ../../examples/dry_run/customized_executor.py
 
 aggregator_entry: aggregator.py
 
@@ -30,13 +31,13 @@ setup_commands:
 
 job_conf: 
     - job_name: dryrun                   # Generate logs under this folder: log_path/job_name/time_stamp
-    - log_path: $HOME/FedScale/core/evals # Path of log files
+    - log_path: $HOME/FedScale/evals # Path of log files
     - total_worker: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: $HOME/FedScale/dataset/data/    # Path of the dataset
     - model: shufflenet_v2_x2_0                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
-    - eval_interval: 1000                     # How many rounds to run a testing on the testing set
-    - epochs: 200                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - eval_interval: 5                     # How many rounds to run a testing on the testing set
+    - rounds: 200                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples
     - num_loaders: 2
     - local_steps: 20

--- a/evals/configs/others/ldp.yml
+++ b/evals/configs/others/ldp.yml
@@ -31,7 +31,7 @@ setup_commands:
 
 job_conf:
     - job_name: ldp                   # Generate logs under this folder: log_path/job_name/time_stamp
-    - log_path: $HOME/FedScale/core/evals # Path of log files
+    - log_path: $HOME/FedScale/evals # Path of log files
     - total_worker: 10
     - data_set: femnist                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: $HOME/FedScale/dataset/data/femnist  # Path of the dataset

--- a/evals/configs/others/rl_conf.yml
+++ b/evals/configs/others/rl_conf.yml
@@ -22,7 +22,7 @@ worker_ips:
     - 10.0.0.13:[4]
     - 10.0.0.14:[4]
 
-exp_path: $HOME/FedScale/core
+exp_path: $HOME/FedScale/fedscale/core
 
 # Entry function of executor and aggregator under $exp_path
 executor_entry: executor.py
@@ -43,7 +43,7 @@ setup_commands:
 
 job_conf: 
     - job_name: rl                   # Generate logs under this folder: log_path/job_name/time_stamp
-    - log_path: $HOME/FedScale/core/evals # Path of log files
+    - log_path: $HOME/FedScale/evals # Path of log files
     - total_worker: 100                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - device_conf_file: $HOME/FedScale/dataset/data/device_info/client_device_capacity     # Path of the client trace
     - device_avail_file: $HOME/FedScale/dataset/data/device_info/client_behave_trace

--- a/evals/configs/reddit/conf.yml
+++ b/evals/configs/reddit/conf.yml
@@ -20,7 +20,7 @@ worker_ips:
     - 10.0.0.12:[4]
     - 10.0.0.13:[4]
 
-exp_path: $HOME/FedScale/core
+exp_path: $HOME/FedScale/fedscale/core
 
 # Entry function of executor and aggregator under $exp_path
 executor_entry: executor.py
@@ -41,7 +41,7 @@ setup_commands:
 
 job_conf: 
     - job_name: reddit                   # Generate logs under this folder: log_path/job_name/time_stamp
-    - log_path: $HOME/FedScale/core/evals # Path of log files
+    - log_path: $HOME/FedScale/evals # Path of log files
     - task: nlp
     - total_worker: 100                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: blog                     # Dataset: openImg, google_speech, reddit

--- a/evals/configs/speech/conf.yml
+++ b/evals/configs/speech/conf.yml
@@ -20,7 +20,7 @@ worker_ips:
     - 10.0.0.12:[4]
     - 10.0.0.13:[4]
 
-exp_path: $HOME/FedScale/core
+exp_path: $HOME/FedScale/fedscale/core
 
 # Entry function of executor and aggregator under $exp_path
 executor_entry: executor.py
@@ -41,7 +41,7 @@ setup_commands:
 
 job_conf: 
     - job_name: google_speech                   # Generate logs under this folder: log_path/job_name/time_stamp
-    - log_path: $HOME/FedScale/core/evals # Path of log files
+    - log_path: $HOME/FedScale/evals # Path of log files
     - task: speech
     - total_worker: 100                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: google_speech                     # Dataset: openImg, google_speech, stackoverflow

--- a/fedscale/core/aggregator.py
+++ b/fedscale/core/aggregator.py
@@ -1,61 +1,70 @@
 # -*- coding: utf-8 -*-
 
+from cmath import log
+from fedscale.core import response
 from fedscale.core.fl_aggregator_libs import *
-from random import Random
 from fedscale.core.resource_manager import ResourceManager
-from fedscale.core.communication.channel_context import ExecutorConnections
-from fedscale.core.response import BasicResponse
-
+from fedscale.core import events
+from fedscale.core import job_api_pb2
 import fedscale.core.job_api_pb2_grpc as job_api_pb2_grpc
-import fedscale.core.job_api_pb2 as job_api_pb2
-import grpc
-import io
+
 import torch
-import pickle
 from torch.utils.tensorboard import SummaryWriter
 import threading
+import pickle
+import grpc
+from concurrent import futures
 
-class Aggregator(object):
+MAX_MESSAGE_LENGTH = 1*1024*1024*1024 # 1GB
+
+class Aggregator(job_api_pb2_grpc.JobServiceServicer):
     """This centralized aggregator collects training/testing feedbacks from executors"""
     def __init__(self, args):
         logging.info(f"Job args {args}")
 
         self.args = args
+        self.experiment_mode = args.experiment_mode
         self.device = args.cuda_device if args.use_cuda else torch.device('cpu')
 
         # ======== env information ========
         self.this_rank = 0
         self.global_virtual_clock = 0.
         self.round_duration = 0.
-        self.resource_manager = ResourceManager()
+        self.resource_manager = ResourceManager(self.experiment_mode)
         self.client_manager = self.init_client_manager(args=args)
 
         # ======== model and data ========
         self.model = None
-
-        # list of parameters in model.parameters()
         self.model_in_update = 0
         self.update_lock = threading.Lock()
         self.last_global_model = []
         self.model_state_dict = None
 
         # ======== channels ========
+        self.connection_timeout = self.args.connection_timeout
         self.executors = None
+        self.grpc_server = None
 
-        # event queue of its own functions
-        self.event_queue = collections.deque()
-        self.client_result_queue = []
+        # ======== Event Queue =======
+        self.individual_client_events = {}    # Unicast 
+        self.sever_events_queue = collections.deque()
+        self.broadcast_events_queue = collections.deque() # Broadcast
 
         # ======== runtime information ========
         self.tasks_round = 0
+        # NOTE: sampled_participants = sampled_executors in deployment, 
+        # because every participant is an executor. However, in simulation mode,
+        # executors is the physical machines (VMs), thus: 
+        # |sampled_executors| << |sampled_participants| as an VM may run multiple participants
         self.sampled_participants = []
+        self.sampled_executors = []
 
         self.round_stragglers = []
         self.model_update_size = 0.
 
         self.collate_fn = None
         self.task = args.task
-        self.epoch = 0
+        self.round = 0
 
         self.start_run_time = time.time()
         self.client_conf = {}
@@ -90,12 +99,11 @@ class Aggregator(object):
                     break
                 except Exception as e:
                     assert i != torch.cuda.device_count()-1, 'Can not find available GPUs'
-
-        self.init_control_communication()
-        self.init_data_communication()
         self.optimizer = ServerOptimizer(self.args.gradient_policy, self.args, self.device)
 
+
     def setup_seed(self, seed=1):
+        """Set global random seed for better reproducibility"""
         torch.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)
         np.random.seed(seed)
@@ -107,7 +115,32 @@ class Aggregator(object):
         # Create communication channel between aggregator and worker
         # This channel serves control messages
         logging.info(f"Initiating control plane communication ...")
-        self.executors = ExecutorConnections(self.args.executor_configs, self.args.base_port)
+        if self.experiment_mode == events.SIMULATION_MODE:
+            num_of_executors = 0
+            for ip_numgpu in self.args.executor_configs.split("="):
+                ip, numgpu = ip_numgpu.split(':')
+                for numexe in numgpu.strip()[1:-1].split(','):
+                    for _ in range(int(numexe.strip())):
+                        num_of_executors += 1
+            self.executors = list(range(num_of_executors))
+        else:
+            self.executors = []
+
+        # initiate a server process
+        self.grpc_server = grpc.server(
+            futures.ThreadPoolExecutor(max_workers=20),
+            options=[
+                ('grpc.max_send_message_length', MAX_MESSAGE_LENGTH),
+                ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
+            ],
+        )
+        job_api_pb2_grpc.add_JobServiceServicer_to_server(self, self.grpc_server)
+        port = '[::]:{}'.format(self.args.ps_port)
+
+        logging.info(f'%%%%%%%%%% Opening aggregator sever using port {port} %%%%%%%%%%')
+
+        self.grpc_server.add_insecure_port(port)
+        self.grpc_server.start()
 
 
     def init_data_communication(self):
@@ -142,7 +175,7 @@ class Aggregator(object):
         return client_manager
 
     def load_client_profile(self, file_path):
-        # load client profiles
+        """For Simulation Mode: load client profiles/traces"""
         global_client_profile = {}
         if os.path.exists(file_path):
             with open(file_path, 'rb') as fin:
@@ -163,14 +196,13 @@ class Aggregator(object):
 
             clientId = 1
             logging.info(f"Loading {len(info['size'])} client traces ...")
-
             for _size in info['size']:
                 # since the worker rankId starts from 1, we also configure the initial dataId as 1
                 mapped_id = clientId%len(self.client_profiles) if len(self.client_profiles) > 0 else 1
                 systemProfile = self.client_profiles.get(mapped_id, {'computation': 1.0, 'communication':1.0})
                 self.client_manager.registerClient(executorId, clientId, size=_size, speed=systemProfile)
                 self.client_manager.registerDuration(clientId, batch_size=self.args.batch_size,
-                    upload_epoch=self.args.local_steps, upload_size=self.model_update_size, download_size=self.model_update_size)
+                    upload_step=self.args.local_steps, upload_size=self.model_update_size, download_size=self.model_update_size)
                 clientId += 1
 
             logging.info("Info of all feasible clients {}".format(self.client_manager.getDataInfo()))
@@ -180,58 +212,65 @@ class Aggregator(object):
 
 
     def tictak_client_tasks(self, sampled_clients, num_clients_to_collect):
-        """We try to remove dummy events as much as possible, by removing the stragglers/offline clients in overcommitment"""
+        if self.experiment_mode == events.SIMULATION_MODE:
+            # NOTE: We try to remove dummy events as much as possible in simulations, 
+            # by removing the stragglers/offline clients in overcommitment"""
+            sampledClientsReal = []
+            completionTimes = []
+            completed_client_clock = {}
+            # 1. remove dummy clients that are not available to the end of training
+            for client_to_run in sampled_clients:
+                client_cfg = self.client_conf.get(client_to_run, self.args)
 
-        sampledClientsReal = []
-        completionTimes = []
-        completed_client_clock = {}
-        # 1. remove dummy clients that are not available to the end of training
-        for client_to_run in sampled_clients:
-            client_cfg = self.client_conf.get(client_to_run, self.args)
+                exe_cost = self.client_manager.getCompletionTime(client_to_run,
+                                        batch_size=client_cfg.batch_size, upload_step=client_cfg.local_steps,
+                                        upload_size=self.model_update_size, download_size=self.model_update_size)
 
-            exe_cost = self.client_manager.getCompletionTime(client_to_run,
-                                    batch_size=client_cfg.batch_size, upload_epoch=client_cfg.local_steps,
-                                    upload_size=self.model_update_size, download_size=self.model_update_size)
+                roundDuration = exe_cost['computation'] + exe_cost['communication']
+                # if the client is not active by the time of collection, we consider it is lost in this round
+                if self.client_manager.isClientActive(client_to_run, roundDuration + self.global_virtual_clock):
+                    sampledClientsReal.append(client_to_run)
+                    completionTimes.append(roundDuration)
+                    completed_client_clock[client_to_run] = exe_cost
 
-            roundDuration = exe_cost['computation'] + exe_cost['communication']
-            # if the client is not active by the time of collection, we consider it is lost in this round
-            if self.client_manager.isClientActive(client_to_run, roundDuration + self.global_virtual_clock):
-                sampledClientsReal.append(client_to_run)
-                completionTimes.append(roundDuration)
-                completed_client_clock[client_to_run] = exe_cost
+            num_clients_to_collect = min(num_clients_to_collect, len(completionTimes))
+            # 2. get the top-k completions to remove stragglers
+            sortedWorkersByCompletion = sorted(range(len(completionTimes)), key=lambda k:completionTimes[k])
+            top_k_index = sortedWorkersByCompletion[:num_clients_to_collect]
+            clients_to_run = [sampledClientsReal[k] for k in top_k_index]
 
-        num_clients_to_collect = min(num_clients_to_collect, len(completionTimes))
-        # 2. get the top-k completions to remove stragglers
-        sortedWorkersByCompletion = sorted(range(len(completionTimes)), key=lambda k:completionTimes[k])
-        top_k_index = sortedWorkersByCompletion[:num_clients_to_collect]
-        clients_to_run = [sampledClientsReal[k] for k in top_k_index]
+            dummy_clients = [sampledClientsReal[k] for k in sortedWorkersByCompletion[num_clients_to_collect:]]
+            round_duration = completionTimes[top_k_index[-1]]
+            completionTimes.sort()
 
-        dummy_clients = [sampledClientsReal[k] for k in sortedWorkersByCompletion[num_clients_to_collect:]]
-        round_duration = completionTimes[top_k_index[-1]]
-        completionTimes.sort()
-
-        return clients_to_run, dummy_clients, completed_client_clock, round_duration, completionTimes[:num_clients_to_collect]
-
+            return clients_to_run, dummy_clients, completed_client_clock, round_duration, completionTimes[:num_clients_to_collect]
+        else:
+            completed_client_clock = {client:1 for client in sampled_clients}
+            return sampled_clients, sampled_clients, completed_client_clock, 1, list(completed_client_clock.values())
 
     def run(self):
         self.setup_env()
         self.model = self.init_model()
         self.save_last_param()
-
         self.model_update_size = sys.getsizeof(pickle.dumps(self.model))/1024.0*8. # kbits
         self.client_profiles = self.load_client_profile(file_path=self.args.device_conf_file)
+
+        self.init_control_communication()
+        self.init_data_communication()
         self.event_monitor()
 
 
     def select_participants(self, select_num_participants, overcommitment=1.3):
-        return sorted(self.client_manager.resampleClients(int(select_num_participants*overcommitment), cur_time=self.global_virtual_clock))
+        return sorted(self.client_manager.resampleClients(
+            int(select_num_participants*overcommitment), cur_time=self.global_virtual_clock))
 
 
     def client_completion_handler(self, results):
         """We may need to keep all updates from clients, if so, we need to append results to the cache"""
         # Format:
-        #       -results = {'clientId':clientId, 'update_weight': model_param, 'moving_loss': epoch_train_loss,
+        #       -results = {'clientId':clientId, 'update_weight': model_param, 'moving_loss': round_train_loss,
         #       'trained_size': count, 'wall_duration': time_cost, 'success': is_success 'utility': utility}
+
         if self.args.gradient_policy in ['q-fedavg']:
             self.client_training_results.append(results)
 
@@ -239,9 +278,11 @@ class Aggregator(object):
         self.stats_util_accumulator.append(results['utility'])
         self.loss_accumulator.append(results['moving_loss'])
 
-        self.client_manager.registerScore(results['clientId'], results['utility'], auxi=math.sqrt(results['moving_loss']),
-            time_stamp=self.epoch,
-            duration=self.virtual_client_clock[results['clientId']]['computation']+self.virtual_client_clock[results['clientId']]['communication']
+        self.client_manager.registerScore(results['clientId'], results['utility'], 
+            auxi=math.sqrt(results['moving_loss']),
+            time_stamp=self.round,
+            duration=self.virtual_client_clock[results['clientId']]['computation']+
+                self.virtual_client_clock[results['clientId']]['communication']
         )
 
         device = self.device
@@ -254,7 +295,6 @@ class Aggregator(object):
         # importance = 1./self.tasks_round
 
         self.update_lock.acquire()
-
         # ================== Aggregate weights ======================
 
         self.model_in_update += 1
@@ -280,39 +320,35 @@ class Aggregator(object):
 
 
     def round_weight_handler(self, last_model, current_model):
-        if self.epoch > 1:
+        if self.round > 1:
             self.optimizer.update_round_gradient(last_model, current_model, self.model)
 
 
     def round_completion_handler(self):
         self.global_virtual_clock += self.round_duration
-        self.epoch += 1
+        self.round += 1
 
-        if self.epoch % self.args.decay_epoch == 0:
+        if self.round % self.args.decay_round == 0:
             self.args.learning_rate = max(self.args.learning_rate*self.args.decay_factor, self.args.min_learning_rate)
 
         # handle the global update w/ current and last
         self.round_weight_handler(self.last_global_model, [param.data.clone() for param in self.model.parameters()])
 
-        avgUtilLastEpoch = sum(self.stats_util_accumulator)/max(1, len(self.stats_util_accumulator))
+        avgUtilLastround = sum(self.stats_util_accumulator)/max(1, len(self.stats_util_accumulator))
         # assign avg reward to explored, but not ran workers
         for clientId in self.round_stragglers:
-            self.client_manager.registerScore(clientId, avgUtilLastEpoch,
-                    time_stamp=self.epoch,
+            self.client_manager.registerScore(clientId, avgUtilLastround,
+                    time_stamp=self.round,
                     duration=self.virtual_client_clock[clientId]['computation']+self.virtual_client_clock[clientId]['communication'],
                     success=False)
 
         avg_loss = sum(self.loss_accumulator)/max(1, len(self.loss_accumulator))
-        logging.info(f"Wall clock: {round(self.global_virtual_clock)} s, Epoch: {self.epoch}, Planned participants: " + \
+        logging.info(f"Wall clock: {round(self.global_virtual_clock)} s, round: {self.round}, Planned participants: " + \
             f"{len(self.sampled_participants)}, Succeed participants: {len(self.stats_util_accumulator)}, Training loss: {avg_loss}")
 
         # dump round completion information to tensorboard
         if len(self.loss_accumulator):
-            self.log_writer.add_scalar('Train/round_to_loss', avg_loss, self.epoch)
-
-            self.log_writer.add_scalar('FAR/time_to_train_loss (min)', avg_loss, self.global_virtual_clock/60.)
-            self.log_writer.add_scalar('FAR/round_duration (min)', self.round_duration/60., self.epoch)
-            self.log_writer.add_histogram('FAR/client_duration (min)', self.flatten_client_duration, self.epoch)
+            self.log_train_result(avg_loss)
 
         # update select participants
         self.sampled_participants = self.select_participants(
@@ -320,11 +356,17 @@ class Aggregator(object):
         clientsToRun, round_stragglers, virtual_client_clock, round_duration, flatten_client_duration = self.tictak_client_tasks(
                         self.sampled_participants, self.args.total_worker)
 
-        logging.info(f"Selected participants to run: {clientsToRun}:\n{virtual_client_clock}")
+        logging.info(f"Selected participants to run: {clientsToRun}")
 
         # Issue requests to the resource manager; Tasks ordered by the completion time
         self.resource_manager.register_tasks(clientsToRun)
         self.tasks_round = len(clientsToRun)
+
+        # Update executors and participants
+        if self.experiment_mode == events.SIMULATION_MODE:
+            self.sampled_executors = list(self.individual_client_events.keys())
+        else:
+            self.sampled_executors = [str(c_id) for c_id in self.sampled_participants]
 
         self.save_last_param()
         self.round_stragglers = round_stragglers
@@ -336,21 +378,41 @@ class Aggregator(object):
         self.stats_util_accumulator = []
         self.client_training_results = []
 
-        if self.epoch >= self.args.epochs:
-            self.event_queue.append('stop')
-        elif self.epoch % self.args.eval_interval == 0:
-            self.event_queue.append('update_model')
-            self.event_queue.append('test')
+        if self.round >= self.args.rounds:
+            self.broadcast_aggregator_events(events.SHUT_DOWN)
+        elif self.round % self.args.eval_interval == 0:
+            self.broadcast_aggregator_events(events.UPDATE_MODEL)
+            self.broadcast_aggregator_events(events.MODEL_TEST)
         else:
-            self.event_queue.append('update_model')
-            self.event_queue.append('start_round')
+            self.broadcast_aggregator_events(events.UPDATE_MODEL)
+            self.broadcast_aggregator_events(events.START_ROUND)
+
+    def log_train_result(self, avg_loss):
+        """Result will be post on TensorBoard"""
+        self.log_writer.add_scalar('Train/round_to_loss', avg_loss, self.round)
+        self.log_writer.add_scalar('FAR/time_to_train_loss (min)', avg_loss, self.global_virtual_clock/60.)
+        self.log_writer.add_scalar('FAR/round_duration (min)', self.round_duration/60., self.round)
+        self.log_writer.add_histogram('FAR/client_duration (min)', self.flatten_client_duration, self.round)
+
+    def log_test_result(self):
+        self.log_writer.add_scalar('Test/round_to_loss', self.testing_history['perf'][self.round]['loss'], self.round)
+        self.log_writer.add_scalar('Test/round_to_accuracy', self.testing_history['perf'][self.round]['top_1'], self.round)
+        self.log_writer.add_scalar('FAR/time_to_test_loss (min)', self.testing_history['perf'][self.round]['loss'],
+                                    self.global_virtual_clock/60.)
+        self.log_writer.add_scalar('FAR/time_to_test_accuracy (min)', self.testing_history['perf'][self.round]['top_1'],
+                                    self.global_virtual_clock/60.)
 
 
-    def testing_completion_handler(self, responses):
-        """Each executor will handle a subset of testing dataset
-        """
-        response = pickle.loads(responses.result().serialized_test_response)
-        executorId, results = response['executorId'], response['results']
+    def deserialize_response(self, responses):
+        return pickle.loads(responses)
+
+    def serialize_response(self, responses):
+        return pickle.dumps(responses)
+
+    def testing_completion_handler(self, client_id, results):
+        """Each executor will handle a subset of testing dataset"""
+
+        results = results['results']
 
         # List append is thread-safe
         self.test_result_accumulator.append(results)
@@ -370,147 +432,198 @@ class Aggregator(object):
                     for key in accumulator:
                         accumulator[key] += self.test_result_accumulator[i][key]
             if self.args.task == "detection":
-                self.testing_history['perf'][self.epoch] = {'round': self.epoch, 'clock': self.global_virtual_clock,
+                self.testing_history['perf'][self.round] = {'round': self.round, 'clock': self.global_virtual_clock,
                     'top_1': round(accumulator['top_1']*100.0/len(self.test_result_accumulator), 4),
                     'top_5': round(accumulator['top_5']*100.0/len(self.test_result_accumulator), 4),
                     'loss': accumulator['test_loss'],
                     'test_len': accumulator['test_len']
-                    }
+                }
             else:
-                self.testing_history['perf'][self.epoch] = {'round': self.epoch, 'clock': self.global_virtual_clock,
+                self.testing_history['perf'][self.round] = {'round': self.round, 'clock': self.global_virtual_clock,
                     'top_1': round(accumulator['top_1']/accumulator['test_len']*100.0, 4),
                     'top_5': round(accumulator['top_5']/accumulator['test_len']*100.0, 4),
                     'loss': accumulator['test_loss']/accumulator['test_len'],
                     'test_len': accumulator['test_len']
-                    }
+                }
 
 
-            logging.info("FL Testing in epoch: {}, virtual_clock: {}, top_1: {} %, top_5: {} %, test loss: {:.4f}, test len: {}"
-                    .format(self.epoch, self.global_virtual_clock, self.testing_history['perf'][self.epoch]['top_1'],
-                    self.testing_history['perf'][self.epoch]['top_5'], self.testing_history['perf'][self.epoch]['loss'],
-                    self.testing_history['perf'][self.epoch]['test_len']))
+            logging.info("FL Testing in round: {}, virtual_clock: {}, top_1: {} %, top_5: {} %, test loss: {:.4f}, test len: {}"
+                    .format(self.round, self.global_virtual_clock, self.testing_history['perf'][self.round]['top_1'],
+                    self.testing_history['perf'][self.round]['top_5'], self.testing_history['perf'][self.round]['loss'],
+                    self.testing_history['perf'][self.round]['test_len']))
 
             # Dump the testing result
             with open(os.path.join(logDir, 'testing_perf'), 'wb') as fout:
                 pickle.dump(self.testing_history, fout)
 
             if len(self.loss_accumulator):
-                self.log_writer.add_scalar('Test/round_to_loss', self.testing_history['perf'][self.epoch]['loss'], self.epoch)
-                self.log_writer.add_scalar('Test/round_to_accuracy', self.testing_history['perf'][self.epoch]['top_1'], self.epoch)
-                self.log_writer.add_scalar('FAR/time_to_test_loss (min)', self.testing_history['perf'][self.epoch]['loss'],
-                                            self.global_virtual_clock/60.)
-                self.log_writer.add_scalar('FAR/time_to_test_accuracy (min)', self.testing_history['perf'][self.epoch]['top_1'],
-                                            self.global_virtual_clock/60.)
+                self.log_test_result()
 
-            self.event_queue.append('start_round')
+            self.broadcast_events_queue.append(events.START_ROUND)
 
+
+    def broadcast_aggregator_events(self, event):
+        """Issue tasks (events) to aggregator worker processes"""
+        self.broadcast_events_queue.append(event)
+
+    def dispatch_client_events(self, event, clients=None):
+        """Issue tasks (events) to clients"""
+        if clients is None:
+            clients = self.sampled_executors
+
+        for client_id in clients:
+            self.individual_client_events[client_id].append(event)
 
     def get_client_conf(self, clientId):
-        # learning rate scheduler
-        conf = {}
-        conf['learning_rate'] = self.args.learning_rate
-        conf['model'] = None
+        """Training configurations that will be applied on clients"""
+
+        conf = {
+            'learning_rate': self.args.learning_rate,
+            'model': None # none indicates we are using the global model
+        }
         return conf
 
     def create_client_task(self, executorId):
         """Issue a new client training task to the executor"""
 
         next_clientId = self.resource_manager.get_next_task()
-
-        if next_clientId is not None:
+        train_config = None
+        # NOTE: model = None then the executor will load the global model broadcasted in UPDATE_MODEL
+        model = None 
+        if next_clientId != None:
             config = self.get_client_conf(next_clientId)
+            train_config = {'client_id': next_clientId, 'task_config': config}
+        return train_config, model
 
-            future_response = self.executors.get_stub(executorId).Train.future(
-                job_api_pb2.TrainRequest(client_id=next_clientId, serialized_train_config=pickle.dumps(config)))
+    
+    def get_test_config(self, client_id):
+        """FL model testing on clients"""
 
-            future_response.add_done_callback(self.task_completion_handler)
+        return {'client_id':client_id}
+
+    def get_global_model(self):
+        """Get global model that would be used by all FL clients (in default FL)"""
+        return self.model
+    
+    def get_shutdown_config(self, client_id):
+        return {'client_id': client_id}
+
+    def add_event_handler(self, client_id, event, meta, data):
+        """ Due to the large volume of requests, we will put all events into a queue first."""
+        self.sever_events_queue.append((client_id, event, meta, data))
 
 
-    def fetch_completion_handler(self, responses):
-        training_result = pickle.loads(responses.result().serialized_fetch_response)
-        self.client_result_queue.append(training_result)
+    def CLIENT_REGISTER(self, request, context):
+        """FL Client register to the aggregator"""
+
+        # NOTE: client_id = executor_id in deployment, 
+        # while multiple client_id uses the same executor_id (VMs) in simulations
+        executor_id = request.executor_id
+        executor_info = self.deserialize_response(request.executor_info)
+        if executor_id not in self.individual_client_events:
+            logging.info(f"Detect new client: {executor_id}, executor info: {executor_info}")
+            self.individual_client_events[executor_id] = collections.deque()
+        else:
+            logging.info(f"Previous client: {executor_id} resumes connecting")
+
+        # We can customize whether to admit the clients here
+        self.executor_info_handler(executor_id, executor_info)
+        
+        return job_api_pb2.ServerResponse(event=events.DUMMY_EVENT,
+                meta=None, data=None)
 
 
-    def task_completion_handler(self, responses):
-        """Handler for training completion on each executor"""
+    def CLIENT_PING(self, request, context):
+        """Handle client requests"""
 
-        response = pickle.loads(responses.result().serialized_train_response)
-        executorId, results = response.executorId, response.status
+        # NOTE: client_id = executor_id in deployment, 
+        # while multiple client_id may use the same executor_id (VMs) in simulations
+        executor_id, client_id = request.executor_id, request.client_id
+        response_data = response_msg = None
 
-        # Schedule a new task first to pipeline computation and communication
-        self.create_client_task(executorId)
+        if len(self.individual_client_events[executor_id]) == 0:
+            # send dummy response
+            current_event = events.DUMMY_EVENT
+            response_data = response_msg = events.DUMMY_RESPONSE
+        else:
+            current_event = self.individual_client_events[executor_id].popleft()
+            if current_event == events.CLIENT_TRAIN:
+                response_msg, response_data = self.create_client_task(client_id)
+                if response_msg is None:
+                    current_event = events.DUMMY_EVENT
+            elif current_event == events.MODEL_TEST:
+                response_msg = self.get_test_config(client_id)
+            elif current_event == events.UPDATE_MODEL:
+                response_data = self.get_global_model()
+            elif current_event == events.SHUT_DOWN:
+                response_msg = self.get_shutdown_config(executor_id)
 
-        # Fetch model updates
-        if results is False:
-            logging.error(f"Executor {executorId} fails to run client {response.clientId}, due to {response.error}")
+        response_msg, response_data = self.serialize_response(response_msg), self.serialize_response(response_data)
+        # NOTE: in simulation mode, response data is pickle for faster (de)serialization
+        return job_api_pb2.ServerResponse(event=current_event,
+                meta=response_msg, data=response_data)
 
-        fetch_response = self.executors.get_stub(executorId).Fetch.future(
-                                job_api_pb2.FetchRequest(client_id=response.clientId))
 
-        fetch_response.add_done_callback(self.fetch_completion_handler)
+    def CLIENT_EXECUTE_COMPLETION(self, request, context):
+        """FL clients complete the execution task."""
+
+        executor_id, client_id, event = request.executor_id, request.client_id, request.event
+        execution_status, execution_msg = request.status, request.msg
+        meta_result, data_result = request.meta_result, request.data_result
+
+        if event == events.CLIENT_TRAIN:
+            # Training results may be uploaded in CLIENT_EXECUTE_RESULT request later, 
+            # so we need to specify whether to ask client to do so (in case of straggler/timeout in real FL).
+            if execution_status is False:
+                logging.error(f"Executor {executor_id} fails to run client {client_id}, due to {execution_msg}")
+            if self.resource_manager.has_next_task(executor_id):
+                # NOTE: we do not pop the train immediately in simulation mode,
+                # since the executor may run multiple clients
+                self.individual_client_events[executor_id].appendleft(events.CLIENT_TRAIN)
+
+        elif event in (events.MODEL_TEST, events.UPLOAD_MODEL):
+            self.add_event_handler(executor_id, event, meta_result, data_result)
+        else:
+            logging.error(f"Received undefined event {event} from client {client_id}")
+        return self.CLIENT_PING(request, context)
 
 
     def event_monitor(self):
         logging.info("Start monitoring events ...")
-        start_time = time.time()
-        time.sleep(20)
-
-        while time.time() - start_time < 2000:
-            try:
-                self.executors.open_grpc_connection()
-                for executorId in self.executors:
-                    response = self.executors.get_stub(executorId).ReportExecutorInfo(
-                        job_api_pb2.ReportExecutorInfoRequest())
-                    self.executor_info_handler(executorId, {"size": response.training_set_size})
-                break
-
-            except Exception as e:
-                self.executors.close_grpc_connection()
-                logging.warning(f"{e}: Have not received executor information. This may due to slow data loading (e.g., Reddit)")
-                time.sleep(30)
-
-        logging.info("Have received all executor information")
 
         while True:
-            if len(self.event_queue) != 0:
-                event_msg = self.event_queue.popleft()
+            # Broadcast events to clients
+            if len(self.broadcast_events_queue) > 0:
+                current_event = self.broadcast_events_queue.popleft()
 
-                if event_msg == 'update_model':
-                    serialized_data = pickle.dumps(self.model.to(device='cpu'))
+                if current_event in (events.UPDATE_MODEL, events.MODEL_TEST):
+                    self.dispatch_client_events(current_event)
 
-                    future_context = []
-                    for executorId in self.executors:
-                        future_context.append(self.executors.get_stub(executorId).UpdateModel.future(
-                            job_api_pb2.UpdateModelRequest(serialized_tensor=serialized_data)))
-
-                    for context in future_context:
-                        _ = context.result()
-
-                elif event_msg == 'start_round':
-                    for executorId in self.executors:
-                        self.create_client_task(executorId)
-
-                elif event_msg == 'stop':
-                    for executorId in self.executors:
-                        _ = self.executors.get_stub(executorId).Stop.future(job_api_pb2.StopRequest())
-
-                    self.stop()
+                elif current_event == events.START_ROUND:
+                    self.dispatch_client_events(events.CLIENT_TRAIN)
+                
+                elif current_event == events.SHUT_DOWN:
+                    self.dispatch_client_events(events.SHUT_DOWN)
                     break
 
-                elif event_msg == 'test':
-                    for executorId in self.executors:
-                        future_response = self.executors.get_stub(executorId).Test.future(job_api_pb2.TestRequest())
-                        future_response.add_done_callback(self.testing_completion_handler)
+            # Handle events queued on the aggregator
+            elif len(self.sever_events_queue) > 0:
+                client_id, current_event, meta, data = self.sever_events_queue.popleft()
 
-            elif len(self.client_result_queue) > 0:
-                self.client_completion_handler(self.client_result_queue.pop(0))
-                if len(self.stats_util_accumulator) == self.tasks_round:
-                        self.round_completion_handler()
+                if current_event == events.UPLOAD_MODEL:
+                    self.client_completion_handler(self.deserialize_response(data))
+                    if len(self.stats_util_accumulator) == self.tasks_round:
+                            self.round_completion_handler()
+
+                elif current_event == events.MODEL_TEST:
+                    self.testing_completion_handler(client_id, self.deserialize_response(data))
+
+                else:
+                    logging.error(f"Event {current_event} is not defined")
+                
             else:
                 # execute every 100 ms
                 time.sleep(0.1)
-
-        self.executors.close_grpc_connection()
 
 
     def stop(self):

--- a/fedscale/core/client_manager.py
+++ b/fedscale/core/client_manager.py
@@ -66,18 +66,18 @@ class clientManager(object):
     def getClient(self, clientId):
         return self.Clients[self.getUniqueId(0, clientId)]
 
-    def registerDuration(self, clientId, batch_size, upload_epoch, upload_size, download_size):
-        if self.mode == "oort" and  self.getUniqueId(0, clientId) in self.Clients:
+    def registerDuration(self, clientId, batch_size, upload_step, upload_size, download_size):
+        if self.mode == "oort" and self.getUniqueId(0, clientId) in self.Clients:
             exe_cost = self.Clients[self.getUniqueId(0, clientId)].getCompletionTime(
-                    batch_size=batch_size, upload_epoch=upload_epoch,
+                    batch_size=batch_size, upload_step=upload_step,
                     upload_size=upload_size, download_size=download_size
             )
             self.ucbSampler.update_duration(clientId, exe_cost['computation']+exe_cost['communication'])
 
-    def getCompletionTime(self, clientId, batch_size, upload_epoch, upload_size, download_size):
+    def getCompletionTime(self, clientId, batch_size, upload_step, upload_size, download_size):
         
         return self.Clients[self.getUniqueId(0, clientId)].getCompletionTime(
-                batch_size=batch_size, upload_epoch=upload_epoch,
+                batch_size=batch_size, upload_step=upload_step,
                 upload_size=upload_size, download_size=download_size
             )
 

--- a/fedscale/core/communication/channel_context.py
+++ b/fedscale/core/communication/channel_context.py
@@ -1,57 +1,29 @@
 import logging
 import grpc
 import fedscale.core.job_api_pb2_grpc as job_api_pb2_grpc
-import fedscale.core.job_api_pb2 as job_api_pb2
 
-class ExecutorConnections(object):
-    """"Helps aggregator manage its grpc connection with executors."""
-    MAX_MESSAGE_LENGTH = 50000000
+MAX_MESSAGE_LENGTH = 1*1024*1024*1024 # 1GB
+class ClientConnections(object):
+    """"Clients build connections to the cloud aggregator."""
 
-    class _ExecutorContext(object):
-        def __init__(self, executorId):
-            self.id = executorId
-            self.address = None
-            self.channel = None
-            self.stub = None
-
-    def __init__(self, config, base_port=50000):
-        self.executors = {}
+    def __init__(self, aggregator_address, base_port=18888):
         self.base_port = base_port
+        self.aggregator_address = aggregator_address
+        self.channel = None
+        self.stub = None
 
-        executorId = 0
-        for ip_numgpu in config.split("="):
-            ip, numgpu = ip_numgpu.split(':')
-            for numexe in numgpu.strip()[1:-1].split(','):
-                for _ in range(int(numexe.strip())):
-                    executorId += 1
-                    self.executors[executorId] = ExecutorConnections._ExecutorContext(executorId)
-                    self.executors[executorId].address = '{}:{}'.format(ip, self.base_port + executorId)
+    def connect_to_server(self):
+        logging.info('%%%%%%%%%% Opening grpc connection to ' + self.aggregator_address + ' %%%%%%%%%%')
+        self.channel = grpc.insecure_channel(
+            '{}:{}'.format(self.aggregator_address, self.base_port),
+            options=[
+                ('grpc.max_send_message_length', MAX_MESSAGE_LENGTH),
+                ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
+            ]
+        )
+        self.stub = job_api_pb2_grpc.JobServiceStub(self.channel)
 
-    def __len__(self):
-        return len(self.executors)
-
-    def __iter__(self):
-        return iter(self.executors)
-
-    def open_grpc_connection(self):
-        for executorId in self.executors:
-            logging.info('%%%%%%%%%% Opening grpc connection to ' + self.executors[executorId].address + ' %%%%%%%%%%')
-            channel = grpc.insecure_channel(
-                self.executors[executorId].address,
-                options=[
-                    ('grpc.max_send_message_length', self.MAX_MESSAGE_LENGTH),
-                    ('grpc.max_receive_message_length', self.MAX_MESSAGE_LENGTH),
-                ]
-            )
-            self.executors[executorId].channel = channel
-            self.executors[executorId].stub = job_api_pb2_grpc.JobServiceStub(channel)
-
-    def close_grpc_connection(self):
-        for executorId in self.executors:
-            logging.info(f'%%%%%%%%%% Closing grpc connection with {executorId} %%%%%%%%%%')
-            self.executors[executorId].channel.close()
-
-    def get_stub(self, executorId):
-        return self.executors[executorId].stub
-
+    def close_sever_connection(self):
+        logging.info('%%%%%%%%%% Closing grpc connection to the aggregator %%%%%%%%%%')
+        self.channel.close()
 

--- a/fedscale/core/communication/job_api.proto
+++ b/fedscale/core/communication/job_api.proto
@@ -7,53 +7,34 @@ syntax = "proto3";
 package fedscale;
 
 service JobService {
-    rpc UpdateModel (UpdateModelRequest) returns (UpdateModelResponse) {}
-    rpc Train (TrainRequest) returns (TrainResponse) {}
-    rpc Fetch (FetchRequest) returns (FetchResponse) {}
-    rpc Stop (StopRequest) returns (StopResponse) {}
-    rpc ReportExecutorInfo (ReportExecutorInfoRequest) returns (ReportExecutorInfoResponse) {}
-    rpc Test (TestRequest) returns (TestResponse) {}
+    rpc CLIENT_REGISTER (RegisterRequest) returns (ServerResponse) {}
+    rpc CLIENT_PING (PingRequest) returns (ServerResponse) {}
+    rpc CLIENT_EXECUTE_COMPLETION (CompleteRequest) returns (ServerResponse) {}
 }
 
-message UpdateModelRequest {
-    bytes serialized_tensor = 1;  // TODO: Change it to TensorProto
+message ServerResponse {
+    string event = 1;
+    bytes meta = 2;
+    bytes data = 3;
 }
 
-message UpdateModelResponse {
-    string message = 1;
+message RegisterRequest {
+    string client_id = 1;
+    string executor_id = 2;
+    bytes executor_info = 3;
 }
 
-message TrainRequest {
-    uint64 client_id = 1;
-    bytes serialized_train_config = 2;
+message PingRequest {
+    string client_id = 1;
+    string executor_id = 2;
 }
 
-message TrainResponse {
-    bytes serialized_train_response = 1;
-}
-
-message FetchRequest {
-    uint64 client_id = 1;
-}
-
-message FetchResponse {
-    bytes serialized_fetch_response = 1;
-}
-
-message StopRequest {}
-
-message StopResponse {}
-
-message ReportExecutorInfoRequest {}
-
-message ReportExecutorInfoResponse {
-    repeated int64 training_set_size = 1;
-}
-
-message TestRequest {
-    string message = 1;
-}
-
-message TestResponse {
-    bytes serialized_test_response = 1;
+message CompleteRequest {
+    string client_id = 1;
+    string executor_id = 2;
+    string event = 3;
+    bool status = 4;
+    string msg = 5;
+    string meta_result = 6;
+    bytes data_result = 7;
 }

--- a/fedscale/core/events.py
+++ b/fedscale/core/events.py
@@ -1,0 +1,17 @@
+
+# Define Basic Experiment Setup
+SIMULATION_MODE = 'simulation'
+DEPLOYMENT_MODE = 'deployment'
+
+# Define Basic FL Events
+UPDATE_MODEL = 'update_model'
+MODEL_TEST = 'model_test'
+SHUT_DOWN = 'terminate_executor'
+START_ROUND = 'start_round'
+CLIENT_CONNECT = 'client_connect'
+CLIENT_TRAIN = 'client_train'
+DUMMY_EVENT = 'dummy_event'
+UPLOAD_MODEL = 'upload_model'
+
+# PLACEHOLD
+DUMMY_RESPONSE = None

--- a/fedscale/core/executor.py
+++ b/fedscale/core/executor.py
@@ -2,23 +2,18 @@
 from fedscale.core.fl_client_libs import *
 from argparse import Namespace
 import gc
-from fedscale.core.client import Client
-from fedscale.core.rlclient import RLClient
-from concurrent import futures
-from fedscale.core.response import BasicResponse
-
-import grpc
-import fedscale.core.job_api_pb2_grpc as job_api_pb2_grpc
-import fedscale.core.job_api_pb2 as job_api_pb2
-import io
+import collections
 import torch
 import pickle
 
+from fedscale.core.client import Client
+from fedscale.core.rlclient import RLClient
+from fedscale.core import events
+from fedscale.core.communication.channel_context import ClientConnections
+import fedscale.core.job_api_pb2 as job_api_pb2
 
-MAX_MESSAGE_LENGTH = 50000000
 
-
-class Executor(job_api_pb2_grpc.JobServiceServicer):
+class Executor(object):
     """Each executor takes certain resource to run real training.
        Each run simulates the execution of an individual client"""
     def __init__(self, args):
@@ -28,21 +23,22 @@ class Executor(job_api_pb2_grpc.JobServiceServicer):
         self.num_executors = args.num_executors
         # ======== env information ========
         self.this_rank = args.this_rank
+        self.executor_id = str(self.this_rank)
 
         # ======== model and data ========
         self.model = self.training_sets = self.test_dataset = None
         self.temp_model_path = os.path.join(logDir, 'model_'+str(args.this_rank)+'.pth.tar')
 
         # ======== channels ========
-        self.grpc_server = None
+        self.aggregator_communicator = ClientConnections(args.ps_ip, args.ps_port)
 
         # ======== runtime information ========
         self.collate_fn = None
         self.task = args.task
-        self.epoch = 0
+        self.round = 0
         self.start_run_time = time.time()
         self.received_stop_request = False
-        self.client_task_result = {}
+        self.event_queue = collections.deque()
 
         super(Executor, self).__init__()
 
@@ -83,21 +79,7 @@ class Executor(job_api_pb2_grpc.JobServiceServicer):
     def init_control_communication(self):
         """Create communication channel between coordinator and executor.
         This channel serves control messages."""
-
-        logging.info(f"Connecting to Coordinator ({args.ps_ip}) for control plane communication ...")
-
-        self.grpc_server = grpc.server(
-            futures.ThreadPoolExecutor(max_workers=10),
-            options=[
-                ('grpc.max_send_message_length', MAX_MESSAGE_LENGTH),
-                ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
-            ],
-        )
-        job_api_pb2_grpc.add_JobServiceServicer_to_server(self, self.grpc_server)
-        port = '[::]:{}'.format(self.args.base_port + self.this_rank)
-        self.grpc_server.add_insecure_port(port)
-        self.grpc_server.start()
-        logging.info(f'Started GRPC server at {port} for control plane')
+        self.aggregator_communicator.connect_to_server()
 
 
     def init_data_communication(self):
@@ -142,69 +124,61 @@ class Executor(job_api_pb2_grpc.JobServiceServicer):
         self.setup_communication()
         self.event_monitor()
 
-    def UpdateModel(self, request, context):
-        """A GRPC functionfor JobService invoked by UpdateModel request.
-        """
-        logging.info('Received GRPC UpdateModel request')
-        self.update_model_handler(request)
-        return job_api_pb2.UpdateModelResponse()
+    def dispatch_worker_events(self, request):
+        """Add new events to worker queues"""
+        self.event_queue.append(request)
 
+    def deserialize_response(self, responses):
+        return pickle.loads(responses)
 
-    def Fetch(self, request, context):
-        """A GRPC function for fetching training result for client
-        """
-        clientId = request.client_id
-        serialized_fetch_response = pickle.dumps(self.client_task_result.get(clientId, None))
-        del self.client_task_result[clientId]
+    def serialize_response(self, responses):
+        return pickle.dumps(responses)
 
-        return job_api_pb2.FetchResponse(serialized_fetch_response=serialized_fetch_response)
+    def UpdateModel(self, config):
+        """Receive the broadcasted global model for current round"""
+        self.update_model_handler(model=config)
 
-
-    def Train(self, request, context):
-        """A GRPC function for JobService invoked by Train request.
-        """
-        logging.info(f'Received GRPC Train request')
-        clientId = request.client_id
-        train_config = pickle.loads(request.serialized_train_config)
+    def Train(self, config):
+        """Load train config and data to start training on client """
+        client_id, train_config = config['client_id'], config['task_config']
 
         model = None
         if 'model' in train_config and train_config['model'] is not None:
             model = train_config['model']
 
         client_conf = self.override_conf(train_config)
-        train_res = self.training_handler(clientId=clientId, conf=client_conf, model=model)
-        self.client_task_result[clientId] = train_res
+        train_res = self.training_handler(clientId=client_id, conf=client_conf, model=model)
 
-        return job_api_pb2.TrainResponse(serialized_train_response=
-                pickle.dumps(BasicResponse(executorId=self.this_rank, clientId=clientId, status=True)))
+        # Report execution completion meta information 
+        response = self.aggregator_communicator.stub.CLIENT_EXECUTE_COMPLETION(job_api_pb2.CompleteRequest(
+            client_id = str(client_id), executor_id = self.executor_id,
+            event = events.CLIENT_TRAIN, status = True, msg = None,
+            meta_result = None, data_result = None
+        ))
+        self.dispatch_worker_events(response)
 
+        return client_id, train_res
 
-    def Stop(self, request, context):
-        """A GRPC functionfor JobService invoked by Stop request.
-        """
-        logging.info('Received GRPC Stop request')
-        self.received_stop_request = True
-        return job_api_pb2.StopResponse()
+    def Test(self, config):
+        """Model Testing. By default, we test the accuracy on all data of clients in the test group"""
 
-
-    def ReportExecutorInfo(self, request, context):
-        """A GRPC function for JobService invoked by ReportExecutorInfo request.
-
-        This is called only once when the training starts.
-        """
-        logging.info('Received GRPC ReportExecutorInfo request')
-        response = job_api_pb2.ReportExecutorInfoResponse()
-        response.training_set_size.extend(self.training_sets.getSize()['size'])
-        return response
-
-
-    def Test(self, request, context):
-        """A GRPC function for JobService invoked by Test request.
-        """
-        logging.info('Received GRPC Test request')
         test_res = self.testing_handler(args=self.args)
-        response = {'executorId': self.this_rank, 'results': test_res}
-        return job_api_pb2.TestResponse(serialized_test_response=pickle.dumps(response))
+        test_res = {'executorId': self.this_rank, 'results': test_res}
+
+        # Report execution completion information 
+        response = self.aggregator_communicator.stub.CLIENT_EXECUTE_COMPLETION(job_api_pb2.CompleteRequest(
+            client_id = self.executor_id, executor_id = self.executor_id,
+            event = events.MODEL_TEST, status = True, msg = None,
+            meta_result = None, data_result = self.serialize_response(test_res)
+        ))
+        self.dispatch_worker_events(response)
+
+
+    def Stop(self):
+        """Stop the current executor"""
+
+        self.aggregator_communicator.close_sever_connection()
+        self.received_stop_request = True
 
 
     def report_executor_info_handler(self):
@@ -212,10 +186,10 @@ class Executor(job_api_pb2_grpc.JobServiceServicer):
         return self.training_sets.getSize()
 
 
-    def update_model_handler(self, request):
+    def update_model_handler(self, model):
         """Update the model copy on this executor"""
-        self.model = pickle.loads(request.serialized_tensor)
-        self.epoch += 1
+        self.model = model
+        self.round += 1
 
         # Dump latest model to disk
         with open(self.temp_model_path, 'wb') as model_out:
@@ -250,7 +224,6 @@ class Executor(job_api_pb2_grpc.JobServiceServicer):
         """Train model given client ids"""
 
         # load last global model
-        s_time = time.time()
         client_model = self.load_global_model() if model is None else model
 
         conf.clientId, conf.device = clientId, self.device
@@ -288,25 +261,68 @@ class Executor(job_api_pb2_grpc.JobServiceServicer):
             test_res = test_model(self.this_rank, model, data_loader, device=device, criterion=criterion, tokenizer=tokenizer)
 
             test_loss, acc, acc_5, testResults = test_res
-            logging.info("After aggregation epoch {}, CumulTime {}, eval_time {}, test_loss {}, test_accuracy {:.2f}%, test_5_accuracy {:.2f}% \n"
-                        .format(self.epoch, round(time.time() - self.start_run_time, 4), round(time.time() - evalStart, 4), test_loss, acc*100., acc_5*100.))
+            logging.info("After aggregation round {}, CumulTime {}, eval_time {}, test_loss {}, test_accuracy {:.2f}%, test_5_accuracy {:.2f}% \n"
+                        .format(self.round, round(time.time() - self.start_run_time, 4), round(time.time() - evalStart, 4), test_loss, acc*100., acc_5*100.))
 
         gc.collect()
 
         return testResults
 
+    def client_register(self):
+        """Register the executor information to the aggregator"""
+        response = self.aggregator_communicator.stub.CLIENT_REGISTER(job_api_pb2.RegisterRequest(
+            client_id = self.executor_id,
+            executor_id = self.executor_id,
+            executor_info = self.serialize_response(self.report_executor_info_handler())
+        ))
+        self.dispatch_worker_events(response)
+
+    def client_ping(self):
+        """Ping the aggregator for new task"""
+        response = self.aggregator_communicator.stub.CLIENT_PING(job_api_pb2.PingRequest(
+            client_id = self.executor_id,
+            executor_id = self.executor_id
+        ))
+        self.dispatch_worker_events(response)
 
     def event_monitor(self):
         """Activate event handler once receiving new message"""
         logging.info("Start monitoring events ...")
+        self.client_register()
 
-        while True:
-            if self.received_stop_request:
-                logging.info(f"Terminating (Executor {self.this_rank}) ...")
-                self.grpc_server.stop(0)
-                break
+        while self.received_stop_request == False:
+            if len(self.event_queue) > 0:
+                request = self.event_queue.popleft()
+                current_event = request.event
 
-            time.sleep(1)
+                if current_event == events.CLIENT_TRAIN:
+                    train_config = self.deserialize_response(request.meta)
+                    train_model = self.deserialize_response(request.data)
+                    train_config['model'] =  train_model
+                    client_id, train_res = self.Train(train_config)
+
+                    # Upload model updates 
+                    _ = self.aggregator_communicator.stub.CLIENT_EXECUTE_COMPLETION.future(
+                        job_api_pb2.CompleteRequest(client_id = str(client_id), executor_id = self.executor_id,
+                        event = events.UPLOAD_MODEL, status = True, msg = None,
+                        meta_result = None, data_result = self.serialize_response(train_res)
+                    ))
+
+                elif current_event == events.MODEL_TEST:
+                    self.Test(self.deserialize_response(request.meta))
+
+                elif current_event == events.UPDATE_MODEL:
+                    broadcast_config = self.deserialize_response(request.data)
+                    self.UpdateModel(broadcast_config)
+
+                elif current_event == events.SHUT_DOWN:
+                    self.Stop()
+
+                elif current_event == events.DUMMY_EVENT:
+                    pass
+            else:
+                time.sleep(1)
+                self.client_ping()
 
 
 if __name__ == "__main__":

--- a/fedscale/core/helper/client.py
+++ b/fedscale/core/helper/client.py
@@ -32,14 +32,14 @@ class Client(object):
 
         return False
 
-    def getCompletionTime(self, batch_size, upload_epoch, upload_size, download_size, augmentation_factor=3.0):
+    def getCompletionTime(self, batch_size, upload_step, upload_size, download_size, augmentation_factor=3.0):
         """
            Computation latency: compute_speed is the inference latency of models (ms/sample). As reproted in many papers, 
                                 backward-pass takes around 2x the latency, so we multiple it by 3x;
            Communication latency: communication latency = (pull + push)_update_size/bandwidth;
         """
-        #return (3.0 * batch_size * upload_epoch/float(self.compute_speed) + model_size/float(self.bandwidth))
-        return {'computation':augmentation_factor * batch_size * upload_epoch*float(self.compute_speed)/1000., \
+        #return (3.0 * batch_size * num_steps/float(self.compute_speed) + model_size/float(self.bandwidth))
+        return {'computation':augmentation_factor * batch_size * upload_step*float(self.compute_speed)/1000., \
                 'communication': (upload_size+download_size)/float(self.bandwidth)}
         # return (augmentation_factor * batch_size * upload_epoch*float(self.compute_speed)/1000. + \
         #         (upload_size+download_size)/float(self.bandwidth))

--- a/fedscale/core/job_api_pb2.py
+++ b/fedscale/core/job_api_pb2.py
@@ -3,6 +3,7 @@
 # source: job_api.proto
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -13,560 +14,54 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor.FileDescriptor(
-  name='job_api.proto',
-  package='fedscale',
-  syntax='proto3',
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\rjob_api.proto\x12\x08\x66\x65\x64scale\"/\n\x12UpdateModelRequest\x12\x19\n\x11serialized_tensor\x18\x01 \x01(\x0c\"&\n\x13UpdateModelResponse\x12\x0f\n\x07message\x18\x01 \x01(\t\"B\n\x0cTrainRequest\x12\x11\n\tclient_id\x18\x01 \x01(\x04\x12\x1f\n\x17serialized_train_config\x18\x02 \x01(\x0c\"2\n\rTrainResponse\x12!\n\x19serialized_train_response\x18\x01 \x01(\x0c\"!\n\x0c\x46\x65tchRequest\x12\x11\n\tclient_id\x18\x01 \x01(\x04\"2\n\rFetchResponse\x12!\n\x19serialized_fetch_response\x18\x01 \x01(\x0c\"\r\n\x0bStopRequest\"\x0e\n\x0cStopResponse\"\x1b\n\x19ReportExecutorInfoRequest\"7\n\x1aReportExecutorInfoResponse\x12\x19\n\x11training_set_size\x18\x01 \x03(\x03\"\x1e\n\x0bTestRequest\x12\x0f\n\x07message\x18\x01 \x01(\t\"0\n\x0cTestResponse\x12 \n\x18serialized_test_response\x18\x01 \x01(\x0c\x32\xa7\x03\n\nJobService\x12L\n\x0bUpdateModel\x12\x1c.fedscale.UpdateModelRequest\x1a\x1d.fedscale.UpdateModelResponse\"\x00\x12:\n\x05Train\x12\x16.fedscale.TrainRequest\x1a\x17.fedscale.TrainResponse\"\x00\x12:\n\x05\x46\x65tch\x12\x16.fedscale.FetchRequest\x1a\x17.fedscale.FetchResponse\"\x00\x12\x37\n\x04Stop\x12\x15.fedscale.StopRequest\x1a\x16.fedscale.StopResponse\"\x00\x12\x61\n\x12ReportExecutorInfo\x12#.fedscale.ReportExecutorInfoRequest\x1a$.fedscale.ReportExecutorInfoResponse\"\x00\x12\x37\n\x04Test\x12\x15.fedscale.TestRequest\x1a\x16.fedscale.TestResponse\"\x00\x62\x06proto3'
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rjob_api.proto\x12\x08\x66\x65\x64scale\";\n\x0eServerResponse\x12\r\n\x05\x65vent\x18\x01 \x01(\t\x12\x0c\n\x04meta\x18\x02 \x01(\x0c\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"P\n\x0fRegisterRequest\x12\x11\n\tclient_id\x18\x01 \x01(\t\x12\x13\n\x0b\x65xecutor_id\x18\x02 \x01(\t\x12\x15\n\rexecutor_info\x18\x03 \x01(\x0c\"5\n\x0bPingRequest\x12\x11\n\tclient_id\x18\x01 \x01(\t\x12\x13\n\x0b\x65xecutor_id\x18\x02 \x01(\t\"\x8f\x01\n\x0f\x43ompleteRequest\x12\x11\n\tclient_id\x18\x01 \x01(\t\x12\x13\n\x0b\x65xecutor_id\x18\x02 \x01(\t\x12\r\n\x05\x65vent\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\x08\x12\x0b\n\x03msg\x18\x05 \x01(\t\x12\x13\n\x0bmeta_result\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x61ta_result\x18\x07 \x01(\x0c\x32\xec\x01\n\nJobService\x12H\n\x0f\x43LIENT_REGISTER\x12\x19.fedscale.RegisterRequest\x1a\x18.fedscale.ServerResponse\"\x00\x12@\n\x0b\x43LIENT_PING\x12\x15.fedscale.PingRequest\x1a\x18.fedscale.ServerResponse\"\x00\x12R\n\x19\x43LIENT_EXECUTE_COMPLETION\x12\x19.fedscale.CompleteRequest\x1a\x18.fedscale.ServerResponse\"\x00\x62\x06proto3')
 
 
 
-
-_UPDATEMODELREQUEST = _descriptor.Descriptor(
-  name='UpdateModelRequest',
-  full_name='fedscale.UpdateModelRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='serialized_tensor', full_name='fedscale.UpdateModelRequest.serialized_tensor', index=0,
-      number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=27,
-  serialized_end=74,
-)
-
-
-_UPDATEMODELRESPONSE = _descriptor.Descriptor(
-  name='UpdateModelResponse',
-  full_name='fedscale.UpdateModelResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='message', full_name='fedscale.UpdateModelResponse.message', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=76,
-  serialized_end=114,
-)
-
-
-_TRAINREQUEST = _descriptor.Descriptor(
-  name='TrainRequest',
-  full_name='fedscale.TrainRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='client_id', full_name='fedscale.TrainRequest.client_id', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='serialized_train_config', full_name='fedscale.TrainRequest.serialized_train_config', index=1,
-      number=2, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=116,
-  serialized_end=182,
-)
-
-
-_TRAINRESPONSE = _descriptor.Descriptor(
-  name='TrainResponse',
-  full_name='fedscale.TrainResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='serialized_train_response', full_name='fedscale.TrainResponse.serialized_train_response', index=0,
-      number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=184,
-  serialized_end=234,
-)
-
-
-_FETCHREQUEST = _descriptor.Descriptor(
-  name='FetchRequest',
-  full_name='fedscale.FetchRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='client_id', full_name='fedscale.FetchRequest.client_id', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=236,
-  serialized_end=269,
-)
-
-
-_FETCHRESPONSE = _descriptor.Descriptor(
-  name='FetchResponse',
-  full_name='fedscale.FetchResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='serialized_fetch_response', full_name='fedscale.FetchResponse.serialized_fetch_response', index=0,
-      number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=271,
-  serialized_end=321,
-)
-
-
-_STOPREQUEST = _descriptor.Descriptor(
-  name='StopRequest',
-  full_name='fedscale.StopRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=323,
-  serialized_end=336,
-)
-
-
-_STOPRESPONSE = _descriptor.Descriptor(
-  name='StopResponse',
-  full_name='fedscale.StopResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=338,
-  serialized_end=352,
-)
-
-
-_REPORTEXECUTORINFOREQUEST = _descriptor.Descriptor(
-  name='ReportExecutorInfoRequest',
-  full_name='fedscale.ReportExecutorInfoRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=354,
-  serialized_end=381,
-)
-
-
-_REPORTEXECUTORINFORESPONSE = _descriptor.Descriptor(
-  name='ReportExecutorInfoResponse',
-  full_name='fedscale.ReportExecutorInfoResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='training_set_size', full_name='fedscale.ReportExecutorInfoResponse.training_set_size', index=0,
-      number=1, type=3, cpp_type=2, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=383,
-  serialized_end=438,
-)
-
-
-_TESTREQUEST = _descriptor.Descriptor(
-  name='TestRequest',
-  full_name='fedscale.TestRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='message', full_name='fedscale.TestRequest.message', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=440,
-  serialized_end=470,
-)
-
-
-_TESTRESPONSE = _descriptor.Descriptor(
-  name='TestResponse',
-  full_name='fedscale.TestResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='serialized_test_response', full_name='fedscale.TestResponse.serialized_test_response', index=0,
-      number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=472,
-  serialized_end=520,
-)
-
-DESCRIPTOR.message_types_by_name['UpdateModelRequest'] = _UPDATEMODELREQUEST
-DESCRIPTOR.message_types_by_name['UpdateModelResponse'] = _UPDATEMODELRESPONSE
-DESCRIPTOR.message_types_by_name['TrainRequest'] = _TRAINREQUEST
-DESCRIPTOR.message_types_by_name['TrainResponse'] = _TRAINRESPONSE
-DESCRIPTOR.message_types_by_name['FetchRequest'] = _FETCHREQUEST
-DESCRIPTOR.message_types_by_name['FetchResponse'] = _FETCHRESPONSE
-DESCRIPTOR.message_types_by_name['StopRequest'] = _STOPREQUEST
-DESCRIPTOR.message_types_by_name['StopResponse'] = _STOPRESPONSE
-DESCRIPTOR.message_types_by_name['ReportExecutorInfoRequest'] = _REPORTEXECUTORINFOREQUEST
-DESCRIPTOR.message_types_by_name['ReportExecutorInfoResponse'] = _REPORTEXECUTORINFORESPONSE
-DESCRIPTOR.message_types_by_name['TestRequest'] = _TESTREQUEST
-DESCRIPTOR.message_types_by_name['TestResponse'] = _TESTRESPONSE
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
-UpdateModelRequest = _reflection.GeneratedProtocolMessageType('UpdateModelRequest', (_message.Message,), {
-  'DESCRIPTOR' : _UPDATEMODELREQUEST,
+_SERVERRESPONSE = DESCRIPTOR.message_types_by_name['ServerResponse']
+_REGISTERREQUEST = DESCRIPTOR.message_types_by_name['RegisterRequest']
+_PINGREQUEST = DESCRIPTOR.message_types_by_name['PingRequest']
+_COMPLETEREQUEST = DESCRIPTOR.message_types_by_name['CompleteRequest']
+ServerResponse = _reflection.GeneratedProtocolMessageType('ServerResponse', (_message.Message,), {
+  'DESCRIPTOR' : _SERVERRESPONSE,
   '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.UpdateModelRequest)
+  # @@protoc_insertion_point(class_scope:fedscale.ServerResponse)
   })
-_sym_db.RegisterMessage(UpdateModelRequest)
+_sym_db.RegisterMessage(ServerResponse)
 
-UpdateModelResponse = _reflection.GeneratedProtocolMessageType('UpdateModelResponse', (_message.Message,), {
-  'DESCRIPTOR' : _UPDATEMODELRESPONSE,
+RegisterRequest = _reflection.GeneratedProtocolMessageType('RegisterRequest', (_message.Message,), {
+  'DESCRIPTOR' : _REGISTERREQUEST,
   '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.UpdateModelResponse)
+  # @@protoc_insertion_point(class_scope:fedscale.RegisterRequest)
   })
-_sym_db.RegisterMessage(UpdateModelResponse)
+_sym_db.RegisterMessage(RegisterRequest)
 
-TrainRequest = _reflection.GeneratedProtocolMessageType('TrainRequest', (_message.Message,), {
-  'DESCRIPTOR' : _TRAINREQUEST,
+PingRequest = _reflection.GeneratedProtocolMessageType('PingRequest', (_message.Message,), {
+  'DESCRIPTOR' : _PINGREQUEST,
   '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.TrainRequest)
+  # @@protoc_insertion_point(class_scope:fedscale.PingRequest)
   })
-_sym_db.RegisterMessage(TrainRequest)
+_sym_db.RegisterMessage(PingRequest)
 
-TrainResponse = _reflection.GeneratedProtocolMessageType('TrainResponse', (_message.Message,), {
-  'DESCRIPTOR' : _TRAINRESPONSE,
+CompleteRequest = _reflection.GeneratedProtocolMessageType('CompleteRequest', (_message.Message,), {
+  'DESCRIPTOR' : _COMPLETEREQUEST,
   '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.TrainResponse)
+  # @@protoc_insertion_point(class_scope:fedscale.CompleteRequest)
   })
-_sym_db.RegisterMessage(TrainResponse)
+_sym_db.RegisterMessage(CompleteRequest)
 
-FetchRequest = _reflection.GeneratedProtocolMessageType('FetchRequest', (_message.Message,), {
-  'DESCRIPTOR' : _FETCHREQUEST,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.FetchRequest)
-  })
-_sym_db.RegisterMessage(FetchRequest)
+_JOBSERVICE = DESCRIPTOR.services_by_name['JobService']
+if _descriptor._USE_C_DESCRIPTORS == False:
 
-FetchResponse = _reflection.GeneratedProtocolMessageType('FetchResponse', (_message.Message,), {
-  'DESCRIPTOR' : _FETCHRESPONSE,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.FetchResponse)
-  })
-_sym_db.RegisterMessage(FetchResponse)
-
-StopRequest = _reflection.GeneratedProtocolMessageType('StopRequest', (_message.Message,), {
-  'DESCRIPTOR' : _STOPREQUEST,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.StopRequest)
-  })
-_sym_db.RegisterMessage(StopRequest)
-
-StopResponse = _reflection.GeneratedProtocolMessageType('StopResponse', (_message.Message,), {
-  'DESCRIPTOR' : _STOPRESPONSE,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.StopResponse)
-  })
-_sym_db.RegisterMessage(StopResponse)
-
-ReportExecutorInfoRequest = _reflection.GeneratedProtocolMessageType('ReportExecutorInfoRequest', (_message.Message,), {
-  'DESCRIPTOR' : _REPORTEXECUTORINFOREQUEST,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.ReportExecutorInfoRequest)
-  })
-_sym_db.RegisterMessage(ReportExecutorInfoRequest)
-
-ReportExecutorInfoResponse = _reflection.GeneratedProtocolMessageType('ReportExecutorInfoResponse', (_message.Message,), {
-  'DESCRIPTOR' : _REPORTEXECUTORINFORESPONSE,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.ReportExecutorInfoResponse)
-  })
-_sym_db.RegisterMessage(ReportExecutorInfoResponse)
-
-TestRequest = _reflection.GeneratedProtocolMessageType('TestRequest', (_message.Message,), {
-  'DESCRIPTOR' : _TESTREQUEST,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.TestRequest)
-  })
-_sym_db.RegisterMessage(TestRequest)
-
-TestResponse = _reflection.GeneratedProtocolMessageType('TestResponse', (_message.Message,), {
-  'DESCRIPTOR' : _TESTRESPONSE,
-  '__module__' : 'job_api_pb2'
-  # @@protoc_insertion_point(class_scope:fedscale.TestResponse)
-  })
-_sym_db.RegisterMessage(TestResponse)
-
-
-
-_JOBSERVICE = _descriptor.ServiceDescriptor(
-  name='JobService',
-  full_name='fedscale.JobService',
-  file=DESCRIPTOR,
-  index=0,
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_start=523,
-  serialized_end=946,
-  methods=[
-  _descriptor.MethodDescriptor(
-    name='UpdateModel',
-    full_name='fedscale.JobService.UpdateModel',
-    index=0,
-    containing_service=None,
-    input_type=_UPDATEMODELREQUEST,
-    output_type=_UPDATEMODELRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='Train',
-    full_name='fedscale.JobService.Train',
-    index=1,
-    containing_service=None,
-    input_type=_TRAINREQUEST,
-    output_type=_TRAINRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='Fetch',
-    full_name='fedscale.JobService.Fetch',
-    index=2,
-    containing_service=None,
-    input_type=_FETCHREQUEST,
-    output_type=_FETCHRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='Stop',
-    full_name='fedscale.JobService.Stop',
-    index=3,
-    containing_service=None,
-    input_type=_STOPREQUEST,
-    output_type=_STOPRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='ReportExecutorInfo',
-    full_name='fedscale.JobService.ReportExecutorInfo',
-    index=4,
-    containing_service=None,
-    input_type=_REPORTEXECUTORINFOREQUEST,
-    output_type=_REPORTEXECUTORINFORESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='Test',
-    full_name='fedscale.JobService.Test',
-    index=5,
-    containing_service=None,
-    input_type=_TESTREQUEST,
-    output_type=_TESTRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-])
-_sym_db.RegisterServiceDescriptor(_JOBSERVICE)
-
-DESCRIPTOR.services_by_name['JobService'] = _JOBSERVICE
-
+  DESCRIPTOR._options = None
+  _SERVERRESPONSE._serialized_start=27
+  _SERVERRESPONSE._serialized_end=86
+  _REGISTERREQUEST._serialized_start=88
+  _REGISTERREQUEST._serialized_end=168
+  _PINGREQUEST._serialized_start=170
+  _PINGREQUEST._serialized_end=223
+  _COMPLETEREQUEST._serialized_start=226
+  _COMPLETEREQUEST._serialized_end=369
+  _JOBSERVICE._serialized_start=372
+  _JOBSERVICE._serialized_end=608
 # @@protoc_insertion_point(module_scope)

--- a/fedscale/core/job_api_pb2_grpc.py
+++ b/fedscale/core/job_api_pb2_grpc.py
@@ -14,72 +14,39 @@ class JobServiceStub(object):
         Args:
             channel: A grpc.Channel.
         """
-        self.UpdateModel = channel.unary_unary(
-                '/fedscale.JobService/UpdateModel',
-                request_serializer=job__api__pb2.UpdateModelRequest.SerializeToString,
-                response_deserializer=job__api__pb2.UpdateModelResponse.FromString,
+        self.CLIENT_REGISTER = channel.unary_unary(
+                '/fedscale.JobService/CLIENT_REGISTER',
+                request_serializer=job__api__pb2.RegisterRequest.SerializeToString,
+                response_deserializer=job__api__pb2.ServerResponse.FromString,
                 )
-        self.Train = channel.unary_unary(
-                '/fedscale.JobService/Train',
-                request_serializer=job__api__pb2.TrainRequest.SerializeToString,
-                response_deserializer=job__api__pb2.TrainResponse.FromString,
+        self.CLIENT_PING = channel.unary_unary(
+                '/fedscale.JobService/CLIENT_PING',
+                request_serializer=job__api__pb2.PingRequest.SerializeToString,
+                response_deserializer=job__api__pb2.ServerResponse.FromString,
                 )
-        self.Fetch = channel.unary_unary(
-                '/fedscale.JobService/Fetch',
-                request_serializer=job__api__pb2.FetchRequest.SerializeToString,
-                response_deserializer=job__api__pb2.FetchResponse.FromString,
-                )
-        self.Stop = channel.unary_unary(
-                '/fedscale.JobService/Stop',
-                request_serializer=job__api__pb2.StopRequest.SerializeToString,
-                response_deserializer=job__api__pb2.StopResponse.FromString,
-                )
-        self.ReportExecutorInfo = channel.unary_unary(
-                '/fedscale.JobService/ReportExecutorInfo',
-                request_serializer=job__api__pb2.ReportExecutorInfoRequest.SerializeToString,
-                response_deserializer=job__api__pb2.ReportExecutorInfoResponse.FromString,
-                )
-        self.Test = channel.unary_unary(
-                '/fedscale.JobService/Test',
-                request_serializer=job__api__pb2.TestRequest.SerializeToString,
-                response_deserializer=job__api__pb2.TestResponse.FromString,
+        self.CLIENT_EXECUTE_COMPLETION = channel.unary_unary(
+                '/fedscale.JobService/CLIENT_EXECUTE_COMPLETION',
+                request_serializer=job__api__pb2.CompleteRequest.SerializeToString,
+                response_deserializer=job__api__pb2.ServerResponse.FromString,
                 )
 
 
 class JobServiceServicer(object):
     """Missing associated documentation comment in .proto file."""
 
-    def UpdateModel(self, request, context):
+    def CLIENT_REGISTER(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def Train(self, request, context):
+    def CLIENT_PING(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def Fetch(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def Stop(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def ReportExecutorInfo(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def Test(self, request, context):
+    def CLIENT_EXECUTE_COMPLETION(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -88,35 +55,20 @@ class JobServiceServicer(object):
 
 def add_JobServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
-            'UpdateModel': grpc.unary_unary_rpc_method_handler(
-                    servicer.UpdateModel,
-                    request_deserializer=job__api__pb2.UpdateModelRequest.FromString,
-                    response_serializer=job__api__pb2.UpdateModelResponse.SerializeToString,
+            'CLIENT_REGISTER': grpc.unary_unary_rpc_method_handler(
+                    servicer.CLIENT_REGISTER,
+                    request_deserializer=job__api__pb2.RegisterRequest.FromString,
+                    response_serializer=job__api__pb2.ServerResponse.SerializeToString,
             ),
-            'Train': grpc.unary_unary_rpc_method_handler(
-                    servicer.Train,
-                    request_deserializer=job__api__pb2.TrainRequest.FromString,
-                    response_serializer=job__api__pb2.TrainResponse.SerializeToString,
+            'CLIENT_PING': grpc.unary_unary_rpc_method_handler(
+                    servicer.CLIENT_PING,
+                    request_deserializer=job__api__pb2.PingRequest.FromString,
+                    response_serializer=job__api__pb2.ServerResponse.SerializeToString,
             ),
-            'Fetch': grpc.unary_unary_rpc_method_handler(
-                    servicer.Fetch,
-                    request_deserializer=job__api__pb2.FetchRequest.FromString,
-                    response_serializer=job__api__pb2.FetchResponse.SerializeToString,
-            ),
-            'Stop': grpc.unary_unary_rpc_method_handler(
-                    servicer.Stop,
-                    request_deserializer=job__api__pb2.StopRequest.FromString,
-                    response_serializer=job__api__pb2.StopResponse.SerializeToString,
-            ),
-            'ReportExecutorInfo': grpc.unary_unary_rpc_method_handler(
-                    servicer.ReportExecutorInfo,
-                    request_deserializer=job__api__pb2.ReportExecutorInfoRequest.FromString,
-                    response_serializer=job__api__pb2.ReportExecutorInfoResponse.SerializeToString,
-            ),
-            'Test': grpc.unary_unary_rpc_method_handler(
-                    servicer.Test,
-                    request_deserializer=job__api__pb2.TestRequest.FromString,
-                    response_serializer=job__api__pb2.TestResponse.SerializeToString,
+            'CLIENT_EXECUTE_COMPLETION': grpc.unary_unary_rpc_method_handler(
+                    servicer.CLIENT_EXECUTE_COMPLETION,
+                    request_deserializer=job__api__pb2.CompleteRequest.FromString,
+                    response_serializer=job__api__pb2.ServerResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -129,7 +81,7 @@ class JobService(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
-    def UpdateModel(request,
+    def CLIENT_REGISTER(request,
             target,
             options=(),
             channel_credentials=None,
@@ -139,14 +91,14 @@ class JobService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/UpdateModel',
-            job__api__pb2.UpdateModelRequest.SerializeToString,
-            job__api__pb2.UpdateModelResponse.FromString,
+        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/CLIENT_REGISTER',
+            job__api__pb2.RegisterRequest.SerializeToString,
+            job__api__pb2.ServerResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def Train(request,
+    def CLIENT_PING(request,
             target,
             options=(),
             channel_credentials=None,
@@ -156,14 +108,14 @@ class JobService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/Train',
-            job__api__pb2.TrainRequest.SerializeToString,
-            job__api__pb2.TrainResponse.FromString,
+        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/CLIENT_PING',
+            job__api__pb2.PingRequest.SerializeToString,
+            job__api__pb2.ServerResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def Fetch(request,
+    def CLIENT_EXECUTE_COMPLETION(request,
             target,
             options=(),
             channel_credentials=None,
@@ -173,59 +125,8 @@ class JobService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/Fetch',
-            job__api__pb2.FetchRequest.SerializeToString,
-            job__api__pb2.FetchResponse.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
-
-    @staticmethod
-    def Stop(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/Stop',
-            job__api__pb2.StopRequest.SerializeToString,
-            job__api__pb2.StopResponse.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
-
-    @staticmethod
-    def ReportExecutorInfo(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/ReportExecutorInfo',
-            job__api__pb2.ReportExecutorInfoRequest.SerializeToString,
-            job__api__pb2.ReportExecutorInfoResponse.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
-
-    @staticmethod
-    def Test(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/Test',
-            job__api__pb2.TestRequest.SerializeToString,
-            job__api__pb2.TestResponse.FromString,
+        return grpc.experimental.unary_unary(request, target, '/fedscale.JobService/CLIENT_EXECUTE_COMPLETION',
+            job__api__pb2.CompleteRequest.SerializeToString,
+            job__api__pb2.ServerResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/fedscale/core/resource_manager.py
+++ b/fedscale/core/resource_manager.py
@@ -1,24 +1,44 @@
-import logging
+from fedscale.core import events
+import threading
 
 class ResourceManager(object):
     """Schedule training tasks across GPUs/CPUs"""
 
-    def __init__(self):
+    def __init__(self, experiment_mode):
 
         self.client_run_queue = []
         self.client_run_queue_idx = 0
-
+        self.experiment_mode = experiment_mode
+        self.update_lock = threading.Lock()
     
     def register_tasks(self, clientsToRun):
-        self.client_run_queue = clientsToRun
+        self.client_run_queue = clientsToRun.copy()
         self.client_run_queue_idx = 0
 
+    def remove_client_task(self, client_id):
+        assert(client_id in self.client_run_queue, 
+            f"client task {client_id} is not in task queue")
+        pass
 
-    def get_next_task(self):
-        if self.client_run_queue_idx < len(self.client_run_queue):
-            clientId = self.client_run_queue[self.client_run_queue_idx]
-            self.client_run_queue_idx += 1
-            return clientId
+    def has_next_task(self, client_id=None):
+        exist_next_task = False
+        if self.experiment_mode == events.SIMULATION_MODE:
+            exist_next_task = self.client_run_queue_idx < len(self.client_run_queue)
+        else:
+            exist_next_task = client_id in self.client_run_queue
+        return exist_next_task
 
-        return None
+    def get_next_task(self, client_id=None):
+        next_task_id = None
+        self.update_lock.acquire()
+        if self.experiment_mode == events.SIMULATION_MODE:
+            if self.has_next_task(client_id):
+                next_task_id = self.client_run_queue[self.client_run_queue_idx]
+                self.client_run_queue_idx += 1
+        else:
+            if client_id in self.client_run_queue:
+                next_task_id = client_id
+                self.client_run_queue.remove(next_task_id)
 
+        self.update_lock.release()
+        return next_task_id


### PR DESCRIPTION
I made several changes:

- Change ALL grpc communications from (aggregator to executors) to (executors to aggregator). As such, the aggregator only listens to events. I think this is more practical and can help our future deployment;

- Clarify arguments better and add more context for each function for better API extensions.