### PR TITLE
Support k8s for job submission and management

### DIFF
--- a/benchmark/configs/cifar_cpu/cifar_cpu_docker.yml
+++ b/benchmark/configs/cifar_cpu/cifar_cpu_docker.yml
@@ -1,13 +1,13 @@
-# Configuration file of dry run experiment using Aggregator & Executor containers
+# Configuration file of FAR training experiment using Aggregator & Executor containers and docker for container deployment
 
 # ========== Container configuration ========== 
 # whether to use container deployment
-use_container: True
+use_container: docker
 
 # containers need port-mapping to communicate with host machine
 # E.g., 1 aggregator and 2 executor, ports: [Aggr, Exec1, Exec2]
-# Note for this example, we can use port 20011 on both Exec1 and Exec2 because they locate on different host machines
-ports: [20010, 20011, 20011]
+# Note for this example, we can use port 20020 on both Aggr and Exec1 because they locate on different host machines
+ports: [20020, 20020, 20021]
 
 # containers need a Docker network to communicate with each other
 # Create a network by: docker network create --driver=overlay --attachable fedscale-net
@@ -25,8 +25,7 @@ ps_ip: 10.0.0.1
 # Note that if we collocate ps and worker on same GPU, then we need to decrease this number of available processes on that GPU by 1
 # E.g., master node has 4 available processes, then 1 for the ps, and worker should be set to: worker:3
 worker_ips: 
-    - 10.0.0.1:[1] # worker_ip: [(# processes on gpu) for gpu in available_gpus] eg. 10.0.0.2:[4,4,4,4] This node has 4 gpus, each gpu has 4 processes. 
-    - 10.0.0.2:[1]
+    - 10.0.0.2:[2] # worker_ip: [(# processes on gpu) for gpu in available_gpus] eg. 10.0.0.2:[4,4,4,4] This node has 4 gpus, each gpu has 4 processes. 
 
 exp_path: $FEDSCALE_HOME/examples/containerization
 
@@ -41,25 +40,26 @@ auth:
 
 # cmd to run before we can indeed run FAR (in order)
 setup_commands:
-
+    
 
 # ========== Additional job configuration ========== 
 # Default parameters are specified in config_parser.py, wherein more description of the parameter can be found
 
 # We use fixed paths in job_conf as they will be accessed inside containers
 job_conf: 
-    - job_name: dryrun_ctnr                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - job_name: cifar_docker                   # Generate logs under this folder: log_path/job_name/time_stamp
     - log_path: /FedScale/benchmark # Path of log files
     - num_participants: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: /FedScale/benchmark/dataset/data/    # Path of the dataset
-    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - model: shufflenet_v2_x2_0              # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
+#    - model_zoo: fedscale-zoo              # Default zoo (torchcv) uses the pytorchvision zoo, which can not support small images well
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
-    - rounds: 20                       # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - rounds: 21                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples
     - num_loaders: 2
     - local_steps: 20
-    - learning_rate: 0.001
+    - learning_rate: 0.05
     - batch_size: 32
     - test_bsz: 32
     - use_cuda: False

--- a/benchmark/configs/cifar_cpu/cifar_cpu_k8s.yml
+++ b/benchmark/configs/cifar_cpu/cifar_cpu_k8s.yml
@@ -1,38 +1,22 @@
-# Configuration file of FAR training experiment using Aggregator & Executor containers
+# Configuration file of FAR training experiment using Aggregator & Executor containers and k8s for container deployment
 
 # ========== Container configuration ========== 
 # whether to use container deployment
-use_container: True
-
-# containers need port-mapping to communicate with host machine
-# E.g., 1 aggregator and 2 executor, ports: [Aggr, Exec1, Exec2]
-# Note for this example, we can use port 20020 on both Aggr and Exec1 because they locate on different host machines
-ports: [20020, 20020, 20021]
-
-# containers need a Docker network to communicate with each other
-# Create a network by: docker network create --driver=overlay --attachable fedscale-net
-container_network: fedscale-net
+use_container: k8s
 
 # containers need a data-path mount to facilitate dataset reuse
 # We assume the same data-path is used on all host machines
 data_path: $FEDSCALE_HOME/benchmark
 
 # ========== Cluster configuration ========== 
-# ip address of the parameter server (need 1 GPU process)
-ps_ip: 10.0.0.1
+# k8s-specific
+# number of aggregators, right now we only support a single aggregator
+# placeholder for supporting hierarchical aggregator in the future
+num_aggregators: 1
 
-# ip address of each worker:# of available gpus process on each gpu in this node
-# Note that if we collocate ps and worker on same GPU, then we need to decrease this number of available processes on that GPU by 1
-# E.g., master node has 4 available processes, then 1 for the ps, and worker should be set to: worker:3
-worker_ips: 
-    - 10.0.0.2:[2] # worker_ip: [(# processes on gpu) for gpu in available_gpus] eg. 10.0.0.2:[4,4,4,4] This node has 4 gpus, each gpu has 4 processes. 
-
-exp_path: $FEDSCALE_HOME/examples/containerization
-
-# Entry function of executor and aggregator under $exp_path
-executor_entry: executor_ctnr.py
-
-aggregator_entry: aggregator_ctnr.py
+# k8s-specific
+# number of executors
+num_executors: 2
 
 auth:
     ssh_user: ""
@@ -47,7 +31,7 @@ setup_commands:
 
 # We use fixed paths in job_conf as they will be accessed inside containers
 job_conf: 
-    - job_name: cifar_ctnr                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - job_name: cifar_k8s                   # Generate logs under this folder: log_path/job_name/time_stamp
     - log_path: /FedScale/benchmark # Path of log files
     - num_participants: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
@@ -55,7 +39,7 @@ job_conf:
     - model: shufflenet_v2_x2_0              # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-zoo              # Default zoo (torchcv) uses the pytorchvision zoo, which can not support small images well
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
-    - rounds: 20                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - rounds: 21                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples
     - num_loaders: 2
     - local_steps: 20

--- a/benchmark/configs/dry_run/dry_run_docker.yml
+++ b/benchmark/configs/dry_run/dry_run_docker.yml
@@ -1,0 +1,65 @@
+# Configuration file of dry run experiment using Aggregator & Executor containers and docker for container deployment
+
+# ========== Container configuration ========== 
+# whether to use container deployment
+use_container: docker
+
+# containers need port-mapping to communicate with host machine
+# E.g., 1 aggregator and 2 executor, ports: [Aggr, Exec1, Exec2]
+# Note for this example, we can use port 20011 on both Exec1 and Exec2 because they locate on different host machines
+ports: [20010, 20011, 20011]
+
+# containers need a Docker network to communicate with each other
+# Create a network by: docker network create --driver=overlay --attachable fedscale-net
+container_network: fedscale-net
+
+# containers need a data-path mount to facilitate dataset reuse
+# We assume the same data-path is used on all host machines
+data_path: $FEDSCALE_HOME/benchmark
+
+# ========== Cluster configuration ========== 
+# ip address of the parameter server (need 1 GPU process)
+ps_ip: 10.0.0.1
+
+# ip address of each worker:# of available gpus process on each gpu in this node
+# Note that if we collocate ps and worker on same GPU, then we need to decrease this number of available processes on that GPU by 1
+# E.g., master node has 4 available processes, then 1 for the ps, and worker should be set to: worker:3
+worker_ips: 
+    - 10.0.0.1:[1] # worker_ip: [(# processes on gpu) for gpu in available_gpus] eg. 10.0.0.2:[4,4,4,4] This node has 4 gpus, each gpu has 4 processes. 
+    - 10.0.0.2:[1]
+
+exp_path: $FEDSCALE_HOME/examples/containerization
+
+# Entry function of executor and aggregator under $exp_path
+executor_entry: executor_ctnr.py
+
+aggregator_entry: aggregator_ctnr.py
+
+auth:
+    ssh_user: ""
+    ssh_private_key: ~/.ssh/id_rsa
+
+# cmd to run before we can indeed run FAR (in order)
+setup_commands:
+
+
+# ========== Additional job configuration ========== 
+# Default parameters are specified in config_parser.py, wherein more description of the parameter can be found
+
+# We use fixed paths in job_conf as they will be accessed inside containers
+job_conf: 
+    - job_name: dryrun_docker                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - log_path: /FedScale/benchmark # Path of log files
+    - num_participants: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
+    - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
+    - data_dir: /FedScale/benchmark/dataset/data/    # Path of the dataset
+    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - eval_interval: 10                     # How many rounds to run a testing on the testing set
+    - rounds: 20                       # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - filter_less: 0                       # Remove clients w/ less than 21 samples
+    - num_loaders: 2
+    - local_steps: 20
+    - learning_rate: 0.001
+    - batch_size: 32
+    - test_bsz: 32
+    - use_cuda: False

--- a/benchmark/configs/dry_run/dry_run_k8s.yml
+++ b/benchmark/configs/dry_run/dry_run_k8s.yml
@@ -1,0 +1,48 @@
+# Configuration file of dry run experiment using Aggregator & Executor containers and k8s for container deployment
+
+# ========== Container configuration ========== 
+# whether to use container deployment
+use_container: k8s
+
+# containers need a data-path mount to facilitate dataset reuse
+# We assume the same data-path is used on all host machines
+data_path: $FEDSCALE_HOME/benchmark
+
+# ========== Cluster configuration ========== 
+# k8s-specific
+# number of aggregators, right now we only support a single aggregator
+# placeholder for supporting hierarchical aggregator in the future
+num_aggregators: 1
+
+# k8s-specific
+# number of executors
+num_executors: 2
+
+auth:
+    ssh_user: ""
+    ssh_private_key: ~/.ssh/id_rsa
+
+# cmd to run before we can indeed run FAR (in order)
+setup_commands:
+
+
+# ========== Additional job configuration ========== 
+# Default parameters are specified in config_parser.py, wherein more description of the parameter can be found
+
+# We use fixed paths in job_conf as they will be accessed inside containers
+job_conf: 
+    - job_name: dryrun_k8s                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - log_path: /FedScale/benchmark # Path of log files
+    - num_participants: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
+    - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
+    - data_dir: /FedScale/benchmark/dataset/data/    # Path of the dataset
+    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - eval_interval: 10                     # How many rounds to run a testing on the testing set
+    - rounds: 21                       # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - filter_less: 0                       # Remove clients w/ less than 21 samples
+    - num_loaders: 2
+    - local_steps: 20
+    - learning_rate: 0.001
+    - batch_size: 32
+    - test_bsz: 32
+    - use_cuda: False

--- a/benchmark/configs/femnist/conf_docker.yml
+++ b/benchmark/configs/femnist/conf_docker.yml
@@ -48,7 +48,7 @@ setup_commands:
 
 # We use fixed paths in job_conf as they will be accessed inside containers
 job_conf: 
-    - job_name: femnist_ctnr                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - job_name: femnist_docker                   # Generate logs under this folder: log_path/job_name/time_stamp
     - log_path: /FedScale/benchmark # Path of log files
     - num_participants: 50                  # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: femnist                     # Dataset: openImg, google_speech, stackoverflow

--- a/benchmark/configs/femnist/conf_docker.yml
+++ b/benchmark/configs/femnist/conf_docker.yml
@@ -1,0 +1,70 @@
+# Configuration file of FAR training experiment using Aggregator & Executor containers and docker for container deployment
+
+# ========== Container configuration ========== 
+# whether to use docker for container deployment
+use_container: docker
+
+# docker-specific: containers need port-mapping to communicate with host machine
+# E.g., 1 aggregator and 2 executor, ports: [Aggr, Exec1, Exec2]
+# Note for this example, we can use port 20000 on both Aggr and Exec1 because they locate on different host machines
+ports: [20000, 20000, 20001]
+
+# docker-specific: containers need a Docker network to communicate with each other
+# Create a network by: docker network create --driver=overlay --attachable fedscale-net
+container_network: fedscale-net
+
+# containers need a data-path mount to facilitate dataset reuse
+# We assume the same data-path is used on all host machines
+data_path: $FEDSCALE_HOME/benchmark
+
+# ========== Cluster configuration ========== 
+
+# ip address of the parameter server (need 1 GPU process)
+ps_ip: 10.0.0.1
+
+# ip address of each worker:# of available gpus process on each gpu in this node
+# Note that if we collocate ps and worker on same GPU, then we need to decrease this number of available processes on that GPU by 1
+# E.g., master node has 4 available processes, then 1 for the ps, and worker should be set to: worker:3
+worker_ips:
+    - 10.0.0.2:[2]
+
+exp_path: $FEDSCALE_HOME/examples/containerization
+
+# Entry function of executor and aggregator under $exp_path
+executor_entry: executor_ctnr.py
+
+aggregator_entry: aggregator_ctnr.py
+
+auth:
+    ssh_user: ""
+    ssh_private_key: ~/.ssh/id_rsa
+
+# cmd to run before we can indeed run FAR (in order)
+setup_commands:
+
+
+# ========== Additional job configuration ========== 
+# Default parameters are specified in config_parser.py, wherein more description of the parameter can be found
+
+# We use fixed paths in job_conf as they will be accessed inside containers
+job_conf: 
+    - job_name: femnist_ctnr                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - log_path: /FedScale/benchmark # Path of log files
+    - num_participants: 50                  # Number of participants per round, we use K=100 in our paper, large K will be much slower
+    - data_set: femnist                     # Dataset: openImg, google_speech, stackoverflow
+    - data_dir: /FedScale/benchmark/dataset/data/femnist    # Path of the dataset
+    - data_map_file: /FedScale/benchmark/dataset/data/femnist/client_data_mapping/train.csv              # Allocation of data to each client, turn to iid setting if not provided
+    - device_conf_file: /FedScale/benchmark/dataset/data/device_info/client_device_capacity     # Path of the client trace
+    - device_avail_file: /FedScale/benchmark/dataset/data/device_info/client_behave_trace
+    - model: resnet18             # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
+#    - model_zoo: fedscale-zoo
+    - eval_interval: 10                     # How many rounds to run a testing on the testing set
+    - rounds: 20                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - filter_less: 21                       # Remove clients w/ less than 21 samples
+    - num_loaders: 2
+    - local_steps: 5
+    - learning_rate: 0.05
+    - batch_size: 20
+    - test_bsz: 20
+    - use_cuda: False
+

--- a/benchmark/configs/femnist/conf_k8s.yml
+++ b/benchmark/configs/femnist/conf_k8s.yml
@@ -6,7 +6,7 @@ use_container: k8s
 
 # containers need a data-path mount to facilitate dataset reuse
 # We assume the same data-path is used on all host machines
-data_path: /users/yilegu/benchmark
+data_path: $FEDSCALE_HOME/benchmark
 
 # ========== Cluster configuration ========== 
 # k8s-specific
@@ -20,7 +20,7 @@ num_executors: 2
 
 
 auth:
-    ssh_user: "yilegu"
+    ssh_user: ""
     ssh_private_key: ~/.ssh/id_rsa
 
 # cmd to run before we can indeed run FAR (in order)
@@ -32,7 +32,7 @@ setup_commands:
 
 # We use fixed paths in job_conf as they will be accessed inside containers
 job_conf: 
-    - job_name: femnist_ctnr                   # Generate logs under this folder: log_path/job_name/time_stamp
+    - job_name: femnist_k8s                   # Generate logs under this folder: log_path/job_name/time_stamp
     - log_path: /FedScale/benchmark # Path of log files
     - num_participants: 5                  # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: femnist                     # Dataset: openImg, google_speech, stackoverflow

--- a/benchmark/configs/femnist/conf_k8s.yml
+++ b/benchmark/configs/femnist/conf_k8s.yml
@@ -1,42 +1,26 @@
-# Configuration file of FAR training experiment using Aggregator & Executor containers
+# Configuration file of FAR training experiment using Aggregator & Executor containers and k8s for container deployment
 
 # ========== Container configuration ========== 
 # whether to use container deployment
-use_container: True
-
-# containers need port-mapping to communicate with host machine
-# E.g., 1 aggregator and 2 executor, ports: [Aggr, Exec1, Exec2]
-# Note for this example, we can use port 20000 on both Aggr and Exec1 because they locate on different host machines
-ports: [20000, 20000, 20001]
-
-# containers need a Docker network to communicate with each other
-# Create a network by: docker network create --driver=overlay --attachable fedscale-net
-container_network: fedscale-net
+use_container: k8s
 
 # containers need a data-path mount to facilitate dataset reuse
 # We assume the same data-path is used on all host machines
-data_path: $FEDSCALE_HOME/benchmark
+data_path: /users/yilegu/benchmark
 
 # ========== Cluster configuration ========== 
+# k8s-specific
+# number of aggregators, right now we only support a single aggregator
+# placeholder for supporting hierarchical aggregator in the future
+num_aggregators: 1
 
-# ip address of the parameter server (need 1 GPU process)
-ps_ip: 10.0.0.1
+# k8s-specific
+# number of executors
+num_executors: 2
 
-# ip address of each worker:# of available gpus process on each gpu in this node
-# Note that if we collocate ps and worker on same GPU, then we need to decrease this number of available processes on that GPU by 1
-# E.g., master node has 4 available processes, then 1 for the ps, and worker should be set to: worker:3
-worker_ips:
-    - 10.0.0.2:[2]
-
-exp_path: $FEDSCALE_HOME/examples/containerization
-
-# Entry function of executor and aggregator under $exp_path
-executor_entry: executor_ctnr.py
-
-aggregator_entry: aggregator_ctnr.py
 
 auth:
-    ssh_user: ""
+    ssh_user: "yilegu"
     ssh_private_key: ~/.ssh/id_rsa
 
 # cmd to run before we can indeed run FAR (in order)
@@ -50,7 +34,7 @@ setup_commands:
 job_conf: 
     - job_name: femnist_ctnr                   # Generate logs under this folder: log_path/job_name/time_stamp
     - log_path: /FedScale/benchmark # Path of log files
-    - num_participants: 50                  # Number of participants per round, we use K=100 in our paper, large K will be much slower
+    - num_participants: 5                  # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: femnist                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: /FedScale/benchmark/dataset/data/femnist    # Path of the dataset
     - data_map_file: /FedScale/benchmark/dataset/data/femnist/client_data_mapping/train.csv              # Allocation of data to each client, turn to iid setting if not provided
@@ -59,7 +43,7 @@ job_conf:
     - model: resnet18             # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-zoo
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
-    - rounds: 20                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - rounds: 21                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples
     - num_loaders: 2
     - local_steps: 5

--- a/docker/driver.py
+++ b/docker/driver.py
@@ -8,8 +8,12 @@ import subprocess
 import sys
 import time
 import json
+from typing import Dict
 import yaml
 import socket
+
+from kubernetes import client, config, utils
+from yaml_generator import generate_aggr_template, generate_exec_template
 
 
 def flatten(d):
@@ -36,12 +40,21 @@ def process_cmd(yaml_file, local=False):
 
     yaml_conf = load_yaml_conf(yaml_file)
 
-    if 'use_container' in yaml_conf and yaml_conf['use_container']:
-        use_container = True
-        ports = yaml_conf['ports']
+    if 'use_container' in yaml_conf:
+        if yaml_conf['use_container'] == "docker":
+            use_container = "docker"
+            ports = yaml_conf['ports']
+        elif yaml_conf['use_container'] == "k8s":
+            submit_to_k8s(yaml_conf)
+            return
+        else:
+            print(f'Error: unknown use_container:{yaml_conf["use_container"]}, the supported options are ["docker", "k8s"].')
+            exit(1)
     else:
-        use_container = False
+        use_container = "default"
+        
 
+    
     ps_ip = yaml_conf['ps_ip']
     worker_ips, total_gpus = [], []
     cmd_script_list = []
@@ -86,13 +99,13 @@ def process_cmd(yaml_file, local=False):
     total_gpu_processes = sum([sum(x) for x in total_gpus])
 
     # error checking
-    if use_container and total_gpu_processes + 1 != len(ports):
+    if use_container == "docker" and total_gpu_processes + 1 != len(ports):
         print(f'Error: there are {total_gpu_processes + 1} processes but {len(ports)} ports mapped, please check your config file')
         exit(1)
 
     # =========== Submit job to parameter server ============
     running_vms.add(ps_ip)
-    if use_container:
+    if use_container == "docker":
         # store ip, port of each container
         ctnr_dict = dict()
         ps_name = f"fedscale-aggr-{time_stamp}"
@@ -123,12 +136,12 @@ def process_cmd(yaml_file, local=False):
     for worker, gpu in zip(worker_ips, total_gpus):
         running_vms.add(worker)
 
-        if not use_container:
+        if use_container == "default":
             print(f"Starting workers on {worker} ...")
 
         for cuda_id in range(len(gpu)):
             for _ in range(gpu[cuda_id]):
-                if use_container:
+                if use_container == "docker":
                     exec_name = f"fedscale-exec{rank_id}-{time_stamp}"
                     print(f'Starting executor container {exec_name} on {worker}')
                     ctnr_dict[exec_name] = {
@@ -157,14 +170,14 @@ def process_cmd(yaml_file, local=False):
     current_path = os.path.dirname(os.path.abspath(__file__))
     job_name = os.path.join(current_path, job_name)
     with open(job_name, 'wb') as fout:
-        if use_container:
-            job_meta = {'user': submit_user, 'vms': running_vms, 'container_dict': ctnr_dict, 'use_container': True}
+        if use_container == "docker":
+            job_meta = {'user': submit_user, 'vms': running_vms, 'container_dict': ctnr_dict, 'use_container': use_container}
         else:
-            job_meta = {'user': submit_user, 'vms': running_vms, 'use_container': False}
+            job_meta = {'user': submit_user, 'vms': running_vms, 'use_container': use_container}
         pickle.dump(job_meta, fout)
 
     # =========== Container: initialize containers ============
-    if use_container:
+    if use_container == "docker":
         # init aggregator
         send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         start_time = time.time()
@@ -239,18 +252,180 @@ def terminate(job_name):
     with open(job_meta_path, 'rb') as fin:
         job_meta = pickle.load(fin)
 
-    if job_meta['use_container']:
+    if job_meta['use_container'] == "docker":
         for name, meta_dict in job_meta['container_dict'].items():
             print(f"Shutting down container {name} on {meta_dict['ip']}")
             with open(f"{job_name}_logging", 'a') as fout:
                 subprocess.Popen(f'ssh {job_meta["user"]}{meta_dict["ip"]} "docker rm --force {name}"',
                                 shell=True, stdout=fout, stderr=fout)          
+    elif job_meta['use_container'] == "k8s":
+        # for now, assume we run in k8s admin mode, placeholder for client job submission in the future
+        config.load_kube_config()
+        core_api = client.CoreV1Api()
+        for name, meta_dict in job_meta['k8s_dict'].items():
+            print(f"Shutting down container {name}...")
+            core_api.delete_namespaced_pod(name, namespace="default")
+
     else:    
         for vm_ip in job_meta['vms']:
             print(f"Shutting down job on {vm_ip}")
             with open(f"{job_name}_logging", 'a') as fout:
                 subprocess.Popen(f'ssh {job_meta["user"]}{vm_ip} "python {current_path}/shutdown.py {job_name}"',
                                 shell=True, stdout=fout, stderr=fout)
+
+def submit_to_k8s(yaml_conf):
+    # TODO: switch to real deployment configs, pod configs are only for testing usage right now
+    # TODO: check if k8s is online?
+    # for now, assume we run in k8s admin mode, placeholder for client job submission in the future
+    config.load_kube_config()
+    k8s_client = client.ApiClient()
+    core_api = client.CoreV1Api()
+    
+    time_stamp = datetime.datetime.fromtimestamp(
+        time.time()).strftime('%m%d_%H%M%S')
+    running_vms = set()
+    log_path = './logs'
+    submit_user = f"{yaml_conf['auth']['ssh_user']}@" if len(yaml_conf['auth']['ssh_user']) else ""
+
+    job_conf = {'time_stamp': time_stamp,
+                }
+    for conf in yaml_conf['job_conf']:
+        job_conf.update(conf)
+    job_name = job_conf["job_name"]
+
+    conf_script = ''
+    setup_cmd = ''
+    if yaml_conf['setup_commands'] is not None:
+        setup_cmd += (yaml_conf['setup_commands'][0] + ' && ')
+        for item in yaml_conf['setup_commands'][1:]:
+            setup_cmd += (item + ' && ')
+
+    k8s_dict = dict()
+
+    # =========== Submit aggregator to k8s ============
+    # generate aggregator yaml
+    aggr_name = f'fedscale-aggr-{time_stamp}'.replace("_", "-")
+    print(f"Generating yaml for aggregator container {aggr_name}...")
+    aggr_config = {
+        "data_path": yaml_conf['data_path'],
+        "pod_name": aggr_name
+    }
+    aggr_yaml_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), f'{aggr_name}.yaml')
+    generate_aggr_template(aggr_config, aggr_yaml_path)
+
+    print(f"Submitting aggregator container {aggr_name} to k8s...")
+
+    # TODO: logging?
+    utils.create_from_yaml(k8s_client, aggr_yaml_path, namespace="default")
+
+
+    time.sleep(5)
+    # =========== Submit executors to k8s ============
+    for rank_id in range(1, yaml_conf["num_executors"]+1):
+        exec_name = f"fedscale-exec{rank_id}-{time_stamp}".replace("_", "-")
+        # generate executor yaml
+        exec_config = {
+            "data_path": yaml_conf["data_path"],
+            "pod_name": exec_name
+        }
+        k8s_dict[exec_name] = {
+            "type": "executor",
+            "rank_id": rank_id
+        }
+        exec_yaml_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), f'{exec_name}.yaml')
+        generate_exec_template(exec_config, exec_yaml_path)
+        print(f'Submitting executor container {exec_name} to k8s...')
+        # TODO: logging?
+        utils.create_from_yaml(k8s_client, exec_yaml_path, namespace="default")
+    
+    # a cold start would take 5-6min
+    print(f'Waiting aggregator container {aggr_name} to be ready...')
+    aggr_ip = -1
+    start_time = time.time()
+    while time.time() - start_time < 600:
+        resp = core_api.read_namespaced_pod(aggr_name, namespace="default")
+        if resp.status.container_statuses[0].ready:
+            aggr_ip = resp.status.pod_ip
+            break
+        time.sleep(1)
+    if aggr_ip == -1:
+        print(f"Error: aggregator {aggr_name} not ready after maximum waiting time allowed, aborting...")
+        exit(1)
+    
+    k8s_dict[aggr_name] = {
+        "type": "aggregator",
+        "ip": aggr_ip,
+        "rank_id": 0
+    }
+
+    # TODO: refactor the code so that docker/k8s version invoke the same init function
+    print(f'Initializing aggregator container {aggr_name}...')
+    send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    start_time = time.time()
+    while time.time() - start_time <= 10:
+        # avoid busy waiting
+        time.sleep(0.1)
+        try:
+            send_socket.connect((aggr_ip, 30000))
+        except socket.error:
+            continue
+        msg = {}
+        msg["type"] = "aggr_init"
+        msg['data'] = job_conf.copy()
+        msg['data']['this_rank'] = 0
+        msg['data']['num_executors'] = yaml_conf["num_executors"]
+        msg = json.dumps(msg)
+        send_socket.sendall(msg.encode('utf-8'))
+        send_socket.close()
+        break
+    time.sleep(10)
+
+    # TODO: make executors init multi-threaded to boost performance
+    for name, meta_dict in k8s_dict.items():
+        if meta_dict["type"] == "aggregator":
+            continue
+        print(f'Waiting executor container {name} to be ready...')
+        start_time = time.time()
+        exec_ip = -1
+        while time.time() - start_time < 600:
+            resp = core_api.read_namespaced_pod(name, namespace="default")
+            if resp.status.container_statuses[0].ready:
+                exec_ip = resp.status.pod_ip
+                break
+            time.sleep(1)
+        if exec_ip == -1:
+            print(f"Error: executor {name} not ready after maximum waiting time allowed, aborting...")
+            exit(1)
+        # update meta data
+        meta_dict["ip"] = exec_ip
+        print(f'Initializing executor container {name}...')
+        send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        start_time = time.time()
+        while time.time() - start_time <= 10:
+            # avoid busy waiting
+            time.sleep(0.1)
+            try:
+                send_socket.connect((exec_ip, 32000))
+            except socket.error:
+                continue
+            msg = {}
+            msg["type"] = "exec_init"
+            msg['data'] = job_conf.copy()
+            msg['data']['this_rank'] = meta_dict['rank_id']
+            msg['data']['num_executors'] = yaml_conf["num_executors"]
+            # TODO: support CUDA device
+            msg['data']['ps_ip'] = aggr_ip
+            msg = json.dumps(msg)
+            send_socket.sendall(msg.encode('utf-8'))
+            send_socket.close()
+            break            
+
+    current_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), job_name)
+    with open(current_path, "wb") as fout:
+        meta_data = {"user": submit_user, "k8s_dict": k8s_dict, "use_container": "k8s"}
+        pickle.dump(meta_data, fout)
+
+    
 
 print_help: bool = False
 if len(sys.argv) > 1:

--- a/docker/yaml_generator.py
+++ b/docker/yaml_generator.py
@@ -1,0 +1,105 @@
+import yaml
+import sys
+
+def generate_aggr_template(dict, path):
+    """ Generate YAML template for aggregator deployment and save it in the given file
+    """
+    config = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": dict["pod_name"]
+        },
+        "spec": {
+        
+            "containers": [{
+                "name": "fedscale-aggr",
+                "image": "fedscale/fedscale-aggr",
+                "imagePullPolicy": "Always",
+                "ports": [
+                    {
+                        "containerPort": 30000
+                    }
+                ],
+                "volumeMounts": [{
+                    "mountPath": "FedScale/benchmark",
+                    "name": "benchmark",
+                    "readOnly": False
+                    }
+                ]
+                }
+            ],
+            "volumes": [{
+                "name": "benchmark",
+                "hostPath": {
+                    # directory location on host, assume it exists on all nodes
+                    "path": dict["data_path"],
+                    "type": "Directory"
+                }
+            }]
+        }
+    }
+    with open(path, "w") as f:
+        f.write(yaml.dump(config, default_flow_style=False))
+
+    # validate the yaml file in case weird things happen
+    with open(path, "r") as f:
+        try:
+            yaml.safe_load(f)
+            return config
+        except:
+            sys.exit("Generated YAML is not valid, aborting...")
+
+
+def generate_exec_template(dict, path):
+    """ Generate YAML template for executor deployment and save it in the given file
+    """
+    config = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": dict["pod_name"]
+        },
+        "spec": {
+        
+            "containers": [{
+                "name": "fedscale-exec",
+                "image": "fedscale/fedscale-exec",
+                "imagePullPolicy": "Always",
+                "ports": [
+                    {
+                        "containerPort": 32000
+                    }
+                ],
+                "volumeMounts": [{
+                    "mountPath": "FedScale/benchmark",
+                    "name": "benchmark",
+                    "readOnly": False
+                    }
+                ]
+                }
+            ],
+            "volumes": [{
+                "name": "benchmark",
+                "hostPath": {
+                    # directory location on host, assume it exists on all nodes
+                    "path": dict["data_path"],
+                    "type": "Directory"
+                }
+            }]
+        }
+    }
+    with open(path, "w") as f:
+        f.write(yaml.dump(config, default_flow_style=False))
+        
+    # validate the yaml file in case weird things happen
+    with open(path, "r") as f:
+        try:
+            yaml.safe_load(f)
+            return config
+        except:
+            sys.exit("Generated YAML is not valid, aborting...")
+
+# if __name__ == "__main__":
+#     generate_aggr_template({"pod_name": "fedscale-aggr-pod", "data_path": "/users/yilegu/benchmark"}, "generated_aggr.yaml")
+#     generate_exec_template({"pod_name": "fedscale-exec-pod", "data_path": "/users/yilegu/benchmark"}, "generated_exec.yaml")

--- a/environment.yml
+++ b/environment.yml
@@ -29,3 +29,4 @@ dependencies:
     - gdown
     - h5py
     - librosa==0.7.2
+    - kubernetes


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Support using k8s to manage job lifecycles, including job submission, initialization, termination and clean-up. 

<!-- Please give a short summary of the change and the problem this solves. -->
**TODO**: add README for k8s job management tutorial

1. change in `docker/driver.py` is added to use k8s client apis for job management, now the driver will support "default", "docker" and "k8s" modes.
2. add a yaml generator for automating generation of k8s container configs.
3. add new example k8s configs in benchmark
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [x] I've made sure the following tests are passing.
- Testing Configurations
   - k8s
     - [x] Dry Run (20 training rounds & 1 evaluation round)
     - [x] Cifar 10 (20 training rounds & 1 evaluation round)
     - [x] Femnist (20 training rounds & 1 evaluation round)
   - Regression 1: docker
     - [x] Cifar 10 (20 training rounds & 1 evaluation round)
     - [x] Femnist (20 training rounds & 1 evaluation round)
   - Regression 2: default
     - [x] Cifar 10 (20 training rounds & 1 evaluation round)
     - [x] Femnist (20 training rounds & 1 evaluation round)