### PR TITLE
Support GPU jobs in FedScale K8S deployment

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,9 @@ This is a tutorial on how to run FedScale jobs under k8s/docker's management ser
 Kubernetes (k8s) is a popular container management framework used in cloud applications. It is integrated with auto-configured network and offers features like load balancing, autoscaling, which is suitable for deploying FedScale framework. 
 
 ### K8S Setup
-We provide scripts for setting up k8s master and worker nodes from a bare-metal cluster in [this repo](https://github.com/IKACE/k8s_setup). The rest part of k8s deployment tutorial assumes the user has set up a k8s network properly.
+We provide scripts for setting up k8s master and worker nodes from a bare-metal cluster in [this repo](https://github.com/IKACE/k8s_setup). The rest part of k8s deployment tutorial assumes the user has set up a k8s network properly. 
+
+To run GPU jobs, follow [K8S CUDA Plugin Tutorial](https://github.com/IKACE/k8s_setup#kubernetes-cuda-plugin-setup) to setup your k8s cluster with CUDA plugin support. FedScale is also fully integrated with time-slicing GPU feature, follow [ Time-slicing GPU Tutorial](https://github.com/IKACE/k8s_setup#optional-enable-time-slicing-feature) to setup time-slicing GPU feature in your k8s cluster.
 
 ### FedScale K8S Demo
 Example configs for submitting jobs to k8s cluster are provided under `$FEDSCALE_HOME/benchmark/configs` (e.g. `$FEDSCALE_HOME/benchmark/configs/femnist/conf_k8s.yml`). Suppose we want to run `Femnist` job with 1 aggregator and 2 executor, modify the config file `conf_k8s.yml` as following:
@@ -17,6 +19,8 @@ Example configs for submitting jobs to k8s cluster are provided under `$FEDSCALE
 - Specify number of aggregators `num_aggregators: 1`, for now we only support a single aggregator for one job, but we are developing hierarchical aggregators feature that will be added in the future.
 
 - Specify number of executors `num_executors: 2`. 
+
+- Set `use_cuda` flag to `True` if you want to use GPU during the training. If enabled, the executors will be running on CUDA GPUs. Each executor is mapped to a *logical GPU unit*, where the physical GPU could either be an entire single GPU or a time-slicing sharable GPU, depending on your k8s configuration.
 
 - Submit job
 

--- a/docker/driver.py
+++ b/docker/driver.py
@@ -4,6 +4,7 @@ import datetime
 import os
 import pickle
 import random
+import shlex
 import subprocess
 import sys
 import time
@@ -479,12 +480,11 @@ def check_log(job_name):
         for name, meta_dict in job_meta['k8s_dict'].items():
             if meta_dict['type'] != 'aggregator':
                 continue
-            config.load_kube_config()
-            core_api = client.CoreV1Api()
+            # don't use k8s python api here, need interactive log
             print(f"%%%%%%%%%% Start of {name} log %%%%%%%%%%")
-            res = core_api.read_namespaced_pod_log(name, "fedscale")
-            print(res)
-            print(f"%%%%%%%%%% End of {name} log %%%%%%%%%%")
+            cmd = f"kubectl logs {name} --follow -n fedscale"
+            proc = subprocess.Popen(shlex.split(cmd))
+            proc.communicate()
     else:
         print("Error: only support checking job logs running in k8s mode!")
         exit(1)

--- a/docker/driver.py
+++ b/docker/driver.py
@@ -399,48 +399,6 @@ def submit_to_k8s(yaml_conf):
             print(f"Error: unrecognized type {meta_dict['type']}!")
             exit(1)
     
-    # a cold start would take 5-6min
-    # print(f'Waiting aggregator container {aggr_name} to be ready...')
-    # aggr_ip = -1
-    # start_time = time.time()
-    # while time.time() - start_time < 600:
-    #     resp = core_api.read_namespaced_pod(aggr_name, namespace="fedscale")
-    #     if resp.status.container_statuses[0].ready:
-    #         aggr_ip = resp.status.pod_ip
-    #         break
-    #     time.sleep(1)
-    # if aggr_ip == -1:
-    #     print(f"Error: aggregator {aggr_name} not ready after maximum waiting time allowed, aborting...")
-    #     exit(1)
-    
-    # k8s_dict[aggr_name] = {
-    #     "type": "aggregator",
-    #     "ip": aggr_ip,
-    #     "rank_id": 0,
-    #     "yaml_path": aggr_yaml_path
-    # }
-
-    # # TODO: refactor the code so that docker/k8s version invoke the same init function
-    # print(f'Initializing aggregator container {aggr_name}...')
-    # send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    # start_time = time.time()
-    # while time.time() - start_time <= 10:
-    #     # avoid busy waiting
-    #     time.sleep(0.1)
-    #     try:
-    #         send_socket.connect((aggr_ip, 30000))
-    #     except socket.error:
-    #         continue
-    #     msg = {}
-    #     msg["type"] = "aggr_init"
-    #     msg['data'] = job_conf.copy()
-    #     msg['data']['this_rank'] = 0
-    #     msg['data']['num_executors'] = yaml_conf["num_executors"]
-    #     msg = json.dumps(msg)
-    #     send_socket.sendall(msg.encode('utf-8'))
-    #     send_socket.close()
-    #     break
-    # time.sleep(10)
 
     # TODO: make executors init multi-threaded to boost performance
     for name, meta_dict in k8s_dict.items():

--- a/docker/yaml_generator.py
+++ b/docker/yaml_generator.py
@@ -89,6 +89,18 @@ def generate_exec_template(dict, path):
             }]
         }
     }
+    if dict["use_cuda"]: 
+        config["spec"]["containers"][0]["resources"] = {
+            "limits": {
+                "nvidia.com/gpu": 1 # request 1 GPU
+            }
+        }
+        config["spec"]["tolerations"] = [{
+            "key": "nvidia.com/gpu",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+        }]
+
     with open(path, "w") as f:
         f.write(yaml.dump(config, default_flow_style=False))
         

--- a/docker/yaml_generator.py
+++ b/docker/yaml_generator.py
@@ -1,6 +1,7 @@
 import yaml
 import sys
 
+# TODO: on the long run, replace this generator with Helm
 def generate_aggr_template(dict, path):
     """ Generate YAML template for aggregator deployment and save it in the given file
     """
@@ -11,7 +12,7 @@ def generate_aggr_template(dict, path):
             "name": dict["pod_name"]
         },
         "spec": {
-        
+            "restartPolicy": "OnFailure",
             "containers": [{
                 "name": "fedscale-aggr",
                 "image": "fedscale/fedscale-aggr",
@@ -61,7 +62,7 @@ def generate_exec_template(dict, path):
             "name": dict["pod_name"]
         },
         "spec": {
-        
+            "restartPolicy": "OnFailure",
             "containers": [{
                 "name": "fedscale-exec",
                 "image": "fedscale/fedscale-exec",

--- a/fedscale/core/execution/executor.py
+++ b/fedscale/core/execution/executor.py
@@ -448,7 +448,11 @@ class Executor(object):
                     pass
             else:
                 time.sleep(1)
-                self.client_ping()
+                try:
+                    self.client_ping()
+                except Exception as e:
+                    logging.info(f"Caught exception {e} from aggregator, terminating executor {self.this_rank} ...")
+                    break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Support GPU jobs in FedScale K8S deployment, and some quality-of-life enhancements.
<!-- Please give a short summary of the change and the problem this solves. -->

1.  Support training using GPU for FedScale k8s jobs  
2.  Support time-sharing GPU feature so that multiple FedScale k8s jobs can share the same GPU simultaneously (no specific changes in FedScale repo, changes are made solely on k8s infra)
3. Support checking FedScale k8s job progress interactively


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the following tests are passing.
- 1. K8S GPU jobs
   - [x] Dry Run (45 training rounds & 3 evaluation round)
   - [x] Cifar 10 (45 training rounds & 3 evaluation round)
   - [x] Femnist (45 training rounds & 3 evaluation round)
 - 2. **Regression 1**: K8S CPU jobs
   - [x] Dry Run (45 training rounds & 3 evaluation round)
   - [x] Cifar 10 (45 training rounds & 3 evaluation round)
   - [x] Femnist (45 training rounds & 3 evaluation round)
 - 3. **Regression 2**: Original CPU jobs
   - [x] Dry Run (20 training rounds & 1 evaluation round)
   - [x] Cifar 10 (20 training rounds & 1 evaluation round)
   - [x] Femnist (20 training rounds & 1 evaluation round)