### PR TITLE
Async simulation and FedBuff aggregation

### DIFF
--- a/benchmark/configs/fedbuff_femnist/conf.yml
+++ b/benchmark/configs/fedbuff_femnist/conf.yml
@@ -38,7 +38,7 @@ job_conf:
     - device_conf_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_device_capacity     # Path of the client trace
     - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
     - model: resnet18                       # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
-    - model_zoo: fedscale-torch-zoo
+#    - model_zoo: fedscale-torch-zoo
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 1000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/fedbuff_femnist/conf.yml
+++ b/benchmark/configs/fedbuff_femnist/conf.yml
@@ -1,0 +1,52 @@
+# Configuration file of FedBuff femnist training experiment
+
+# ========== Cluster configuration ==========
+# ip address of the parameter server (need 1 GPU process)
+ps_ip: 10.0.0.1
+
+# ip address of each worker:# of available gpus process on each gpu in this node
+# Note that if we collocate ps and worker on same GPU, then we need to decrease this number of available processes on that GPU by 1
+# E.g., master node has 4 available processes, then 1 for the ps, and worker should be set to: worker:3
+worker_ips:
+    - 10.0.0.1:[4]
+
+exp_path: $FEDSCALE_HOME/fedscale/cloud
+
+# Entry function of executor and aggregator under $exp_path
+executor_entry: execution/executor.py
+
+aggregator_entry: aggregation/async_aggregator.py
+
+auth:
+    ssh_user: ""
+    ssh_private_key: ~/.ssh/id_rsa
+
+# cmd to run before we can indeed run FAR (in order)
+setup_commands:
+    - source $HOME/anaconda3/bin/activate fedscale
+
+# ========== Additional job configuration ==========
+# Default parameters are specified in config_parser.py, wherein more description of the parameter can be found
+
+job_conf:
+    - job_name: femnist                     # Generate logs under this folder: log_path/job_name/time_stamp
+    - log_path: $FEDSCALE_HOME/benchmark    # Path of log files
+    - num_participants: 50                  # Number of participants per round, we use K=100 in our paper, large K will be much slower
+    - data_set: femnist                     # Dataset: openImg, google_speech, stackoverflow
+    - data_dir: $FEDSCALE_HOME/benchmark/dataset/data/femnist    # Path of the dataset
+    - data_map_file: $FEDSCALE_HOME/benchmark/dataset/data/femnist/client_data_mapping/train.csv              # Allocation of data to each client, turn to iid setting if not provided
+    - device_conf_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_device_capacity     # Path of the client trace
+    - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
+    - model: resnet18                       # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
+    - model_zoo: fedscale-torch-zoo
+    - eval_interval: 10                     # How many rounds to run a testing on the testing set
+    - rounds: 1000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - filter_less: 21                       # Remove clients w/ less than 21 samples
+    - num_loaders: 2
+    - local_steps: 5
+    - learning_rate: 0.05
+    - batch_size: 20
+    - test_bsz: 20
+    - max_concurrency: 60
+    - max_staleness: 5
+    - use_cuda: True

--- a/examples/heterofl/customized_aggregator.py
+++ b/examples/heterofl/customized_aggregator.py
@@ -46,7 +46,7 @@ class Customized_Aggregator(Aggregator):
         top_k_index = random.sample(sortedWorkersByCompletion, k=num_clients_to_collect)
         clients_to_run = [sampledClientsReal[k] for k in top_k_index]
 
-        dummy_clients = [sampledClientsReal[k] for k in sortedWorkersByCompletion[num_clients_to_collect:]]
+        stragglers = [sampledClientsReal[k] for k in sortedWorkersByCompletion[num_clients_to_collect:]]
         round_duration = completionTimes[top_k_index[-1]]
         completionTimes.sort()
 

--- a/fedscale/cloud/aggregation/aggregator.py
+++ b/fedscale/cloud/aggregation/aggregator.py
@@ -328,12 +328,12 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
             top_k_index = workers_sorted_by_completion_time[:num_clients_to_collect]
             clients_to_run = [sampledClientsReal[k] for k in top_k_index]
 
-            dummy_clients = [sampledClientsReal[k]
-                             for k in workers_sorted_by_completion_time[num_clients_to_collect:]]
+            stragglers = [sampledClientsReal[k]
+                          for k in workers_sorted_by_completion_time[num_clients_to_collect:]]
             round_duration = completionTimes[top_k_index[-1]]
             completionTimes.sort()
 
-            return (clients_to_run, dummy_clients,
+            return (clients_to_run, stragglers,
                     completed_client_clock, round_duration,
                     completionTimes[:num_clients_to_collect])
         else:
@@ -405,11 +405,16 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
         self.update_lock.acquire()
 
         self.model_in_update += 1
-        self.update_weight_aggregation(results['update_weight'])
+        self.update_weight_aggregation(results)
 
         self.update_lock.release()
 
-    def update_weight_aggregation(self, update_weights):
+    def update_weight_aggregation(self, results):
+        """Updates the aggregation with the new results.
+
+        :param results: the results collected from the client.
+        """
+        update_weights = results['update_weight']
         if type(update_weights) is dict:
             update_weights = [x for x in update_weights.values()]
         if self.model_in_update == 1:
@@ -446,7 +451,7 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
         round_perf = self.testing_history['perf'][self.round]
         logging.info(
             "FL Testing in round: {}, virtual_clock: {}, results: {}"
-            .format(self.round, self.global_virtual_clock, round_perf))
+                .format(self.round, self.global_virtual_clock, round_perf))
 
     def update_default_task_config(self):
         """Update the default task configuration after each round
@@ -461,8 +466,7 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
         """
         self.global_virtual_clock += self.round_duration
         self.round += 1
-        last_round_avg_util = sum(self.stats_util_accumulator) / \
-                              max(1, len(self.stats_util_accumulator))
+        last_round_avg_util = sum(self.stats_util_accumulator) / max(1, len(self.stats_util_accumulator))
         # assign avg reward to explored, but not ran workers
         for client_id in self.round_stragglers:
             self.client_manager.register_feedback(client_id, last_round_avg_util,
@@ -471,8 +475,7 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
                                                            self.virtual_client_clock[client_id]['communication'],
                                                   success=False)
 
-        avg_loss = sum(self.loss_accumulator) / \
-                   max(1, len(self.loss_accumulator))
+        avg_loss = sum(self.loss_accumulator) / max(1, len(self.loss_accumulator))
         logging.info(f"Wall clock: {round(self.global_virtual_clock)} s, round: {self.round}, Planned participants: " +
                      f"{len(self.sampled_participants)}, Succeed participants: {len(self.stats_util_accumulator)}, Training loss: {avg_loss}")
 
@@ -483,15 +486,15 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
         # update select participants
         self.sampled_participants = self.select_participants(
             select_num_participants=self.args.num_participants, overcommitment=self.args.overcommitment)
-        (clientsToRun, round_stragglers, virtual_client_clock, round_duration,
+        (clients_to_run, round_stragglers, virtual_client_clock, round_duration,
          flatten_client_duration) = self.tictak_client_tasks(
             self.sampled_participants, self.args.num_participants)
 
-        logging.info(f"Selected participants to run: {clientsToRun}")
+        logging.info(f"Selected participants to run: {clients_to_run}")
 
         # Issue requests to the resource manager; Tasks ordered by the completion time
-        self.resource_manager.register_tasks(clientsToRun)
-        self.tasks_round = len(clientsToRun)
+        self.resource_manager.register_tasks(clients_to_run)
+        self.tasks_round = len(clients_to_run)
 
         # Update executors and participants
         if self.experiment_mode == commons.SIMULATION_MODE:
@@ -634,7 +637,7 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
         }
         return conf
 
-    def create_client_task(self, executorId):
+    def create_client_task(self, executor_id):
         """Issue a new client training task to specific executor
 
         Args:
@@ -644,10 +647,10 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
             tuple: Training config for new task. (dictionary, PyTorch or TensorFlow module)
 
         """
-        next_client_id = self.resource_manager.get_next_task(executorId)
+        next_client_id = self.resource_manager.get_next_task(executor_id)
         train_config = None
         # NOTE: model = None then the executor will load the global model broadcasted in UPDATE_MODEL
-        if next_client_id != None:
+        if next_client_id is not None:
             config = self.get_client_conf(next_client_id)
             train_config = {'client_id': next_client_id, 'task_config': config}
         return train_config, self.model_wrapper.get_weights()

--- a/fedscale/cloud/aggregation/async_aggregator.py
+++ b/fedscale/cloud/aggregation/async_aggregator.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+import copy
+from collections import deque
+from heapq import heappush, heappop
+import numpy as np
+from overrides import overrides
+
+from fedscale.cloud.fllibs import *
+from fedscale.cloud.aggregation.aggregator import Aggregator
+
+
+class AsyncAggregator(Aggregator):
+    """Represents an async aggregator implementing the FedBuff algorithm.
+    Currently, this aggregator only supports simulation mode."""
+
+    def new_task(self, event_time):
+        """Generates a new task that starts at event_time, and inserts it into the min heap.
+
+        :param event_time: the time to start the new task.
+        """
+        client = self.client_manager.select_participants(1, cur_time=event_time)[0]
+        client_cfg = self.client_conf.get(client, self.args)
+
+        exe_cost = self.client_manager.get_completion_time(
+            client,
+            batch_size=client_cfg.batch_size,
+            local_steps=client_cfg.local_steps,
+            upload_size=self.model_update_size,
+            download_size=self.model_update_size)
+        self.virtual_client_clock[client] = exe_cost
+        duration = exe_cost['computation'] + \
+                   exe_cost['communication']
+        end_time = event_time + duration
+        # if the client is not active by the time of collection, we consider it is lost in this round
+        if not self.client_manager.isClientActive(client, duration):
+            pass
+        heappush(self.min_pq, (event_time, 'start', client))
+        heappush(self.min_pq, (end_time, 'end', client))
+        self.client_task_start_times[client] = event_time
+        self.client_task_model_version[client] = self.round
+
+    def create_client_task(self, executor_id):
+        """Issue a new client training task to the specific executor.
+
+        Args:
+            executor_id (int): Executor Id.
+
+        Returns:
+            tuple: Training config for new task. (dictionary, PyTorch or TensorFlow module)
+
+        """
+        next_client_id = self.resource_manager.get_next_task(executor_id)
+        config = self.get_client_conf(next_client_id)
+        train_config = {'client_id': next_client_id, 'task_config': config}
+        model_version = self.client_task_model_version[next_client_id]
+        return train_config, self.model_cache[self.round - model_version]
+
+    def tictak_client_tasks(self, sampled_clients, num_clients_to_collect):
+        """Record sampled client execution information in last round. In the SIMULATION_MODE,
+        further filter the sampled_client and pick the top num_clients_to_collect clients.
+
+        Args:
+            sampled_clients (list of int): Sampled clients from client manager
+            num_clients_to_collect (int): The number of clients actually needed for next round.
+
+        Returns:
+            tuple: Return the sampled clients and client execution information in the last round.
+        """
+        if self.experiment_mode == commons.SIMULATION_MODE:
+            self.model_cache.appendleft(self.model_wrapper.get_weights())
+            if len(self.model_cache) > self.args.max_staleness + 1:
+                self.model_cache.pop()
+            clients_to_run = []
+            durations = []
+            final_time = self.global_virtual_clock
+            if not self.min_pq:
+                self.new_task(self.global_virtual_clock)
+            while len(clients_to_run) < num_clients_to_collect:
+                event_time, event_type, client = heappop(self.min_pq)
+                if event_type == 'start':
+                    self.current_concurrency += 1
+                    if self.current_concurrency < self.args.max_concurrency:
+                        self.new_task(event_time)
+                else:
+                    self.current_concurrency -= 1
+                    if self.current_concurrency == self.args.max_concurrency - 1:
+                        self.new_task(event_time)
+                    if self.round - self.client_task_model_version[client] <= self.args.max_staleness:
+                        clients_to_run.append(client)
+                    durations.append(event_time - self.client_task_start_times[client])
+                    final_time = event_time
+            self.global_virtual_clock = final_time
+            return (clients_to_run, [], self.virtual_client_clock, 0,
+                    durations)
+        else:
+            completed_client_clock = {
+                client: {'computation': 1, 'communication': 1} for client in sampled_clients}
+            times = [1 for _ in sampled_clients]
+            return sampled_clients, sampled_clients, completed_client_clock, 1, times
+
+    def setup_env(self):
+        """Set up environment and variables."""
+        self.setup_seed(seed=1)
+        self.virtual_client_clock = {}
+        self.min_pq = []
+        self.model_cache = deque()
+        self.client_task_start_times = {}
+        self.client_task_model_version = {}
+        self.current_concurrency = 0
+        self.aggregation_denominator = 0
+
+    @overrides
+    def update_weight_aggregation(self, results):
+        """Updates the aggregation with the new results.
+
+        :param results: the results collected from the client.
+        """
+        update_weights = results['update_weight']
+        inverted_staleness = 1 / (1 + self.round - self.client_task_model_version[results['client_id']])
+        self.aggregation_denominator += inverted_staleness
+        if type(update_weights) is dict:
+            update_weights = [x for x in update_weights.values()]
+        if self.model_in_update == 1:
+            self.model_weights = [weight * inverted_staleness for weight in update_weights]
+        else:
+            self.model_weights = [weight + inverted_staleness * update_weights[i] for i, weight in
+                                  enumerate(self.model_weights)]
+        if self.model_in_update == self.tasks_round:
+            self.model_weights = [np.divide(weight, self.aggregation_denominator) for weight in self.model_weights]
+            self.model_wrapper.set_weights(copy.deepcopy(self.model_weights))
+            self.aggregation_denominator = 0
+
+
+if __name__ == "__main__":
+    aggregator = AsyncAggregator(parser.args)
+    aggregator.run()

--- a/fedscale/cloud/aggregation/async_aggregator.py
+++ b/fedscale/cloud/aggregation/async_aggregator.py
@@ -91,8 +91,7 @@ class AsyncAggregator(Aggregator):
                     durations.append(event_time - self.client_task_start_times[client])
                     final_time = event_time
             self.global_virtual_clock = final_time
-            return (clients_to_run, [], self.virtual_client_clock, 0,
-                    durations)
+            return clients_to_run, [], self.virtual_client_clock, 0, durations
         else:
             # Dummy placeholder for non-simulations.
             completed_client_clock = {

--- a/fedscale/cloud/config_parser.py
+++ b/fedscale/cloud/config_parser.py
@@ -19,6 +19,8 @@ parser.add_argument('--engine', type=str, default=commons.PYTORCH,
 parser.add_argument('--num_executors', type=int, default=1)
 parser.add_argument('--executor_configs', type=str,
                     default="127.0.0.1:[1]")  # seperated by ;
+# Note: In async mode, the num_participants param is treated as the async buffer size. In sync, this is the number
+# of clients that are selected each round.
 parser.add_argument('--num_participants', type=int, default=4)
 parser.add_argument('--data_map_file', type=str, default=None)
 parser.add_argument('--use_cuda', type=str, default='True')
@@ -101,18 +103,9 @@ parser.add_argument('--backbone', type=str, default='./resnet50.pth')
 # for malicious
 parser.add_argument('--malicious_factor', type=int, default=1e15)
 
-# for asynchronous FL buffer size
-parser.add_argument('--max_concurrency', type=int, default=100)
-parser.add_argument('--async_buffer', type=int, default=10)
+# for asynchronous FL
+parser.add_argument('--max_concurrency', type=int, default=10)
 parser.add_argument('--max_staleness', type=int, default=5)
-parser.add_argument(
-    '--checkin_period', type=int, default=50, help='number of rounds to sample async clients'
-)
-parser.add_argument('--arrival_interval', type=int, default=3)
-parser.add_argument(
-    "--async_mode", type=bool, default=False, help="use async FL aggregation"
-)
-
 
 # for differential privacy
 parser.add_argument('--noise_factor', type=float, default=0.1)

--- a/fedscale/tests/cloud/aggregation/test_aggregator.py
+++ b/fedscale/tests/cloud/aggregation/test_aggregator.py
@@ -17,7 +17,7 @@ class MockAggregator(Aggregator):
 
 
 def multiply_weights(weights, factor):
-    return [weights_group * factor for weights_group in weights]
+    return {"update_weight": [weights_group * factor for weights_group in weights]}
 
 
 class TestAggregator:


### PR DESCRIPTION
Implements the async simulation mode with FedBuff using device traces without needing a constant arrival parameter, following the min-heap [method described here](https://github.com/SymbioticLab/FedScale/issues/174).

### Benchmarks comparison for Femnist (Sync vs Async with Fedbuff):
#### Sync  / Async
Round: 100 / 180
Virtual clock: 27,618s / 18,913s
Top_5 eval accuracy: 0.914 / 0.92

Params: 5 clients per round, model = resnet18, max_concurrency=10

The results are consistent with the hypothesis that the async scheduling system increases the number of rounds that can be completed within the same amount of virtual clock time, and improves straggler tolerance. They also show the effect of aggregating stale updates from previous rounds, resulting in more rounds before convergence. 

## Checks

- [x] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [x] I've made sure the following tests are passing.
- Testing Configurations
   - [x] Dry Run (20 training rounds & 1 evaluation round)
   - [x] Cifar 10 (20 training rounds & 1 evaluation round)
   - [x] Femnist (20 training rounds & 1 evaluation round)