### PR TITLE
fix bug in optimizer

### DIFF
--- a/fedscale/cloud/aggregation/optimizers.py
+++ b/fedscale/cloud/aggregation/optimizers.py
@@ -1,3 +1,5 @@
+import numpy as np 
+import torch
 class TorchServerOptimizer(object):
     """This is a abstract server optimizer class
     
@@ -40,8 +42,12 @@ class TorchServerOptimizer(object):
             diff_weight = self.gradient_controller.update(
                 [pb-pa for pa, pb in zip(last_model, current_model)])
 
-            for idx, param in enumerate(target_model.parameters()):
-                param.data = last_model[idx] + diff_weight[idx]
+            new_state_dict = {
+                name: torch.from_numpy(np.array(last_model[idx] + diff_weight[idx], dtype=np.float32))
+                for idx, name in enumerate(target_model.state_dict().keys())
+            }
+
+            target_model.load_state_dict(new_state_dict)
 
         elif self.mode == 'q-fedavg':
             """

--- a/fedscale/cloud/internal/torch_model_adapter.py
+++ b/fedscale/cloud/internal/torch_model_adapter.py
@@ -2,7 +2,7 @@ from typing import List
 
 import numpy as np
 import torch
-
+import copy
 from fedscale.cloud.aggregation.optimizers import TorchServerOptimizer
 from fedscale.cloud.internal.model_adapter_base import ModelAdapterBase
 
@@ -32,6 +32,8 @@ class TorchModelAdapter(ModelAdapterBase):
         }
         self.model.load_state_dict(new_state_dict)
         if self.optimizer:
+            weights_origin = copy.deepcopy(weights)
+            weights = [torch.tensor(x) for x in weights_origin]
             self.optimizer.update_round_gradient(weights, current_grad_weights, self.model)
 
     def get_weights(self) -> List[np.ndarray]:


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

+ For the `set_weights` function in `fedscale\cloud\internal\torch_model_adapter.py`, before calling `self.optimizer.update_round_gradient()` (line 35), change the weights from an np. ndarray list to a list of torch.Tensor. This fixes the bug in [issue 229](https://github.com/SymbioticLab/FedScale/issues/229).


+ Modify the model parameter update method in `fedscale\cloud\aggregation\optimizers.py` when the optimization method is `fed-yogi` (line 45). The original method causes the model structure to change so that the parameters cannot be updated again in the next round of training.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

[issue 229](https://github.com/SymbioticLab/FedScale/issues/229)

## Checks

- [√] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [√] I've made sure the following tests are passing.
- Testing Configurations
   - [√] Dry Run (20 training rounds & 1 evaluation round)
   - [√] Cifar 10 (20 training rounds & 1 evaluation round)
   - [√] Femnist (20 training rounds & 1 evaluation round)