### PR TITLE
Fix argument order & renaming

### DIFF
--- a/benchmark/configs/android/mnn.yml
+++ b/benchmark/configs/android/mnn.yml
@@ -25,6 +25,7 @@ job_conf:
     - experiment_mode: mobile
     - num_participants: 1                # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - model: linear                      # Need to define the model in aggregator_mnn.py
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - learning_rate: 0.01
     - batch_size: 32
     - input_shape: 32 32 3

--- a/benchmark/configs/android/tflite.yml
+++ b/benchmark/configs/android/tflite.yml
@@ -25,6 +25,7 @@ job_conf:
     - experiment_mode: mobile
     - num_participants: 1                # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - model: linear                      # Need to define the model in tf_aggregator.py
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - learning_rate: 0.01
     - batch_size: 32
     - input_shape: 32 32 3

--- a/benchmark/configs/cifar_cpu/cifar_cpu.yml
+++ b/benchmark/configs/cifar_cpu/cifar_cpu.yml
@@ -36,6 +36,7 @@ job_conf:
     - data_dir: $FEDSCALE_HOME/benchmark/dataset/data/    # Path of the dataset
     - model: shufflenet_v2_x2_0              # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-torch-zoo              # Default zoo (torchcv) uses the pytorchvision zoo, which can not support small images well
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 5                     # How many rounds to run a testing on the testing set
     - rounds: 600                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/docker_deploy/cifar_cpu_docker.yml
+++ b/benchmark/configs/docker_deploy/cifar_cpu_docker.yml
@@ -55,6 +55,7 @@ job_conf:
     - data_dir: /FedScale/benchmark/dataset/data/    # Path of the dataset
     - model: shufflenet_v2_x2_0              # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-torch-zoo              # Default zoo (torchcv) uses the pytorchvision zoo, which can not support small images well
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 21                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/docker_deploy/dry_run_docker.yml
+++ b/benchmark/configs/docker_deploy/dry_run_docker.yml
@@ -54,7 +54,8 @@ job_conf:
     - num_participants: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: /FedScale/benchmark/dataset/data/    # Path of the dataset
-    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 20                       # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/docker_deploy/femnist_docker.yml
+++ b/benchmark/configs/docker_deploy/femnist_docker.yml
@@ -59,6 +59,7 @@ job_conf:
     - device_avail_file: /FedScale/benchmark/dataset/data/device_info/client_behave_trace
     - model: resnet18             # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-torch-zoo
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 20                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/dry_run/dry_run.yml
+++ b/benchmark/configs/dry_run/dry_run.yml
@@ -35,7 +35,8 @@ job_conf:
     - num_participants: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: $FEDSCALE_HOME/benchmark/dataset/data/    # Path of the dataset
-    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 5                     # How many rounds to run a testing on the testing set
     - rounds: 200                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/fedbuff_femnist/conf.yml
+++ b/benchmark/configs/fedbuff_femnist/conf.yml
@@ -39,6 +39,7 @@ job_conf:
     - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
     - model: resnet18                       # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-torch-zoo
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 1000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/femnist/conf.yml
+++ b/benchmark/configs/femnist/conf.yml
@@ -39,8 +39,9 @@ job_conf:
     - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
     - model: resnet18             # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-torch-zoo
-    - eval_interval: 10                     # How many rounds to run a testing on the testing set
-    - rounds: 1000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
+    - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - eval_interval: 20                     # How many rounds to run a testing on the testing set
+    - rounds: 20                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples
     - num_loaders: 2
     - local_steps: 5

--- a/benchmark/configs/k8s_deploy/cifar_cpu_k8s.yml
+++ b/benchmark/configs/k8s_deploy/cifar_cpu_k8s.yml
@@ -37,6 +37,7 @@ job_conf:
     - data_dir: /FedScale/benchmark/dataset/data/    # Path of the dataset
     - model: shufflenet_v2_x2_0              # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-torch-zoo              # Default zoo (torchcv) uses the pytorchvision zoo, which can not support small images well
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 21                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/k8s_deploy/dry_run_k8s.yml
+++ b/benchmark/configs/k8s_deploy/dry_run_k8s.yml
@@ -35,7 +35,8 @@ job_conf:
     - num_participants: 4                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: /FedScale/benchmark/dataset/data/    # Path of the dataset
-    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - model: resnet18                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 21                       # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/k8s_deploy/femnist_k8s.yml
+++ b/benchmark/configs/k8s_deploy/femnist_k8s.yml
@@ -41,6 +41,7 @@ job_conf:
     - device_avail_file: /FedScale/benchmark/dataset/data/device_info/client_behave_trace
     - model: resnet18             # NOTE: Please refer to our model zoo README and use models for these small image (e.g., 32x32x3) inputs
 #    - model_zoo: fedscale-torch-zoo
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 21                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/others/heterofl.yml
+++ b/benchmark/configs/others/heterofl.yml
@@ -36,7 +36,8 @@ job_conf:
     - num_participants: 10                      # Number of participants per round, we use K=100 in our paper, large K will be much slower
     - data_set: cifar10                     # Dataset: openImg, google_speech, stackoverflow
     - data_dir: $FEDSCALE_HOME/benchmark/dataset/data/    # Path of the dataset
-    - model: resnet_heterofl                      # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2# - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - model: resnet_heterofl                      # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 5                     # How many rounds to run a testing on the testing set
     - rounds: 400                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/reddit/reddit.yml
+++ b/benchmark/configs/reddit/reddit.yml
@@ -50,6 +50,7 @@ job_conf:
     - device_conf_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_device_capacity     # Path of the client trace
     - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
     - model: albert-base-v2                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 30                     # How many rounds to run a testing on the testing set
     - rounds: 5000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/tf_cifar/tf_cifar.yml
+++ b/benchmark/configs/tf_cifar/tf_cifar.yml
@@ -36,6 +36,7 @@ job_conf:
     - data_dir: $FEDSCALE_HOME/benchmark/dataset/data/    # Path of the dataset
     - model: resnet50                    # Need to define the model in tf_aggregator.py
     - model_zoo: fedscale-tensorflow-zoo
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 5000                # How many rounds to run a testing on the testing set
     - rounds: 200                        # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                     # Remove clients w/ less than 21 samples

--- a/benchmark/configs/tf_femnist/tf_femnist.yml
+++ b/benchmark/configs/tf_femnist/tf_femnist.yml
@@ -36,6 +36,7 @@ job_conf:
     - data_dir: $FEDSCALE_HOME/benchmark/dataset/data/femnist    # Path of the dataset
     - model: resnet50                    # Need to define the model in tf_aggregator.py
     - model_zoo: fedscale-tensorflow-zoo
+#   - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 5000                # How many rounds to run a testing on the testing set
     - rounds: 200                        # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 0                     # Remove clients w/ less than 21 samples

--- a/fedscale/cloud/internal/torch_model_adapter.py
+++ b/fedscale/cloud/internal/torch_model_adapter.py
@@ -25,7 +25,7 @@ class TorchModelAdapter(ModelAdapterBase):
         Set the model's weights to the numpy weights array.
         :param weights: numpy weights array
         """
-        current_grad_weights = [param.data.clone() for param in self.model.state_dict().values()]
+        last_grad_weights = [param.data.clone() for param in self.model.state_dict().values()]
         new_state_dict = {
             name: torch.from_numpy(np.asarray(weights[i], dtype=np.float32))
             for i, name in enumerate(self.model.state_dict().keys())
@@ -34,7 +34,7 @@ class TorchModelAdapter(ModelAdapterBase):
         if self.optimizer:
             weights_origin = copy.deepcopy(weights)
             weights = [torch.tensor(x) for x in weights_origin]
-            self.optimizer.update_round_gradient(weights, current_grad_weights, self.model)
+            self.optimizer.update_round_gradient(last_grad_weights, weights, self.model)
 
     def get_weights(self) -> List[np.ndarray]:
         """


### PR DESCRIPTION
@fanlai0990 
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
## Why are these changes needed?
The original functional call `self.optimizer.update_round_gradient()` in `torch_model_adapter` is buggy, I changed the order of the argument, as well as the naming for the past model weights to make it more readable.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #231 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [ ] I've made sure the following tests are passing.
- Testing Configurations
   - [ ] Dry Run (20 training rounds & 1 evaluation round)
   - [x] Cifar 10 (20 training rounds & 1 evaluation round)
   - [x] Femnist (20 training rounds & 1 evaluation round)

I try out Femnist setting using fed-yogi, and can validate that the training loss is indeed decreasing after the change.

For the dry run case, I experienced an issue, which I'll post as a separate issue, but I don't think it is related to this.