### PR TITLE
[Dataset] Fix speech download path

### DIFF
--- a/benchmark/dataset/download.sh
+++ b/benchmark/dataset/download.sh
@@ -49,13 +49,13 @@ speech()
     if [ ! -d "${DIR}/speech_commands/train/" ];
     then
         echo "Downloading Speech Commands dataset(about 2.4GB)..."
-        wget -O ${DIR}/speech_commands/google_speech.tar.gz https://fedscale.eecs.umich.edu/dataset/google_speech.tar.gz
+        wget -O ${DIR}/google_speech.tar.gz https://fedscale.eecs.umich.edu/dataset/google_speech.tar.gz
 
         echo "Dataset downloaded, now decompressing..."
-        tar -xf ${DIR}/speech_commands/google_speech.tar.gz -C ${DIR}
+        tar -xf ${DIR}/google_speech.tar.gz -C ${DIR}
 
         echo "Removing compressed file..."
-        rm -f ${DIR}/speech_commands/google_speech.tar.gz
+        rm -f ${DIR}/google_speech.tar.gz
 
         echo -e "${GREEN}Speech Commands dataset downloaded!${NC}"
     else
@@ -584,3 +584,4 @@ case "$1" in
         Help
     ;;
 esac
+	


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current download path of Google Speech dataset is wrong, leading to failures.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [x] I've made sure the following tests are passing.
- Testing Configurations
   - [x] Dry Run (20 training rounds & 1 evaluation round)
   - [x] Cifar 10 (20 training rounds & 1 evaluation round)
   - [x] Femnist (20 training rounds & 1 evaluation round)