### PR TITLE
Revert "Fix argument order & renaming"

### DIFF
--- a/fedscale/cloud/internal/torch_model_adapter.py
+++ b/fedscale/cloud/internal/torch_model_adapter.py
@@ -25,7 +25,7 @@ class TorchModelAdapter(ModelAdapterBase):
         Set the model's weights to the numpy weights array.
         :param weights: numpy weights array
         """
-        last_grad_weights = [param.data.clone() for param in self.model.state_dict().values()]
+        current_grad_weights = [param.data.clone() for param in self.model.state_dict().values()]
         new_state_dict = {
             name: torch.from_numpy(np.asarray(weights[i], dtype=np.float32))
             for i, name in enumerate(self.model.state_dict().keys())
@@ -34,7 +34,7 @@ class TorchModelAdapter(ModelAdapterBase):
         if self.optimizer:
             weights_origin = copy.deepcopy(weights)
             weights = [torch.tensor(x) for x in weights_origin]
-            self.optimizer.update_round_gradient(last_grad_weights, weights, self.model)
+            self.optimizer.update_round_gradient(weights, current_grad_weights, self.model)
 
     def get_weights(self) -> List[np.ndarray]:
         """


### PR DESCRIPTION
@fanlai0990 @AmberLJC 
This reverts commit 035e0e3a1f0be89a7e41035b80c9f53a6b1f94dc.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The previous fix might be buggy. I found that in the long term (>=20 rounds) the accuracy does not increase with time. I think there might be other bugs apart from `torch_module_adapter`, that did not introduce any issues when coexist with the fixed bug. I will take a look later. Sorry for not checking it thoroughly before making the last PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#235 

<!-- For example: "Closes #1234" -->

## Checks
![Screenshot from 2023-09-06 01-08-07](https://github.com/SymbioticLab/FedScale/assets/70790160/17086775-c631-46d5-a878-b416217dfbe2)

- [ ] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [ ] I've made sure the following tests are passing.
- Testing Configurations
   - [ ] Dry Run (20 training rounds & 1 evaluation round)
   - [ ] Cifar 10 (20 training rounds & 1 evaluation round)
   - [ ] Femnist (20 training rounds & 1 evaluation round)