### PR TITLE
tensorboard library on Macos requires python version >= 3.9

### DIFF
--- a/environment-osx-arm64-general.yml
+++ b/environment-osx-arm64-general.yml
@@ -7,7 +7,7 @@ dependencies:
   - grpcio==1.40.0
   - libprotobuf
   - numba
-  - python=3.8
+  - python=3.9
   - tensorboard
   - pip:
       - fqdn


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

< I am trying to run this framework on my local MacOs(M1 chip). but when I run mentioned(on readme) creating env command, error happens. because tensorboard library on Macos requires python version >= 3.9. 
>

## Related issue number

<->

## Checks

- [ ] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [ ] I've made sure the following tests are passing.
- Testing Configurations
   - [ ] Dry Run (20 training rounds & 1 evaluation round)
   - [ ] Cifar 10 (20 training rounds & 1 evaluation round)
   - [ ] Femnist (20 training rounds & 1 evaluation round)