### PR TITLE
Update driver.py print message

### DIFF
--- a/docker/driver.py
+++ b/docker/driver.py
@@ -243,6 +243,7 @@ def process_cmd(yaml_file, local=False):
 
 
     print(f"Submitted job, please check your logs {job_conf['log_path']}/logs/{job_conf['job_name']}/{time_stamp} for status")
+    print(f"if you cannot find logs directory on the path, you need to check ""{job_name}_logging"" log file under FEDSCALE root directory.")
 
 
 def terminate(job_name):


### PR DESCRIPTION
## Why are these changes needed?

beginner users might be confused by this printed message. Regardless of whether the process successfully work or not, it prints same message with log file path. 

But when process doesn't work because of several each user's env reason, the error log just printed on the {job_name}_logging under root directory. So in this case they need to check this file.

## Related issue number

<X>

## Checks

- [ ] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [ ] I've made sure the following tests are passing.
- Testing Configurations
   - [ ] Dry Run (20 training rounds & 1 evaluation round)
   - [ ] Cifar 10 (20 training rounds & 1 evaluation round)
   - [ ] Femnist (20 training rounds & 1 evaluation round)