### PR TITLE
Fix fed-yogi executor model download

### DIFF
--- a/benchmark/configs/openimage/openimage.yml
+++ b/benchmark/configs/openimage/openimage.yml
@@ -51,7 +51,7 @@ job_conf:
     - device_conf_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_device_capacity     # Path of the client trace
     - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
     - model: shufflenet_v2_x2_0                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
-    - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 30                     # How many rounds to run a testing on the testing set
     - rounds: 5000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/others/local_dp.yml
+++ b/benchmark/configs/others/local_dp.yml
@@ -38,7 +38,7 @@ job_conf:
 #    - device_avail_file: /users/JIACHEN/FLPerf-Cluster/client_datamap/client_behave_trace
     - sample_mode: random                                  # Client selection: random, oort, random by default
     - model: resnet18                            # Models: shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
-    - gradient_policy: fedavg                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - gradient_policy: fed-avg                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 10                     # How many rounds to run a testing on the testing set
     - rounds: 500                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 20

--- a/benchmark/configs/others/rl_conf.yml
+++ b/benchmark/configs/others/rl_conf.yml
@@ -48,7 +48,7 @@ job_conf:
     - device_conf_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_device_capacity     # Path of the client trace
     - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
     - model: dqn                           # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
-    - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 50                     # How many rounds to run a testing on the testing set
     - rounds: 1000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/benchmark/configs/speech/google_speech.yml
+++ b/benchmark/configs/speech/google_speech.yml
@@ -50,7 +50,7 @@ job_conf:
     - device_conf_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_device_capacity     # Path of the client trace
     - device_avail_file: $FEDSCALE_HOME/benchmark/dataset/data/device_info/client_behave_trace
     - model: resnet34                            # Models: e.g., shufflenet_v2_x2_0, mobilenet_v2, resnet34, albert-base-v2
-    - gradient_policy: yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
+    - gradient_policy: fed-yogi                 # {"fed-yogi", "fed-prox", "fed-avg"}, "fed-avg" by default
     - eval_interval: 30                     # How many rounds to run a testing on the testing set
     - rounds: 5000                          # Number of rounds to run this training. We use 1000 in our paper, while it may converge w/ ~400 rounds
     - filter_less: 21                       # Remove clients w/ less than 21 samples

--- a/fedscale/cloud/aggregation/aggregator.py
+++ b/fedscale/cloud/aggregation/aggregator.py
@@ -460,7 +460,10 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
             self.model_weights = [weight + update_weights[i] for i, weight in enumerate(self.model_weights)]
         if self._is_last_result_in_round():
             self.model_weights = [np.divide(weight, self.tasks_round) for weight in self.model_weights]
-            self.model_wrapper.set_weights(copy.deepcopy(self.model_weights))
+            self.model_wrapper.set_weights(
+                copy.deepcopy(self.model_weights),
+                self.client_training_results
+                )
 
 
     def aggregate_test_result(self):

--- a/fedscale/cloud/aggregation/aggregator.py
+++ b/fedscale/cloud/aggregation/aggregator.py
@@ -462,7 +462,7 @@ class Aggregator(job_api_pb2_grpc.JobServiceServicer):
             self.model_weights = [np.divide(weight, self.tasks_round) for weight in self.model_weights]
             self.model_wrapper.set_weights(
                 copy.deepcopy(self.model_weights),
-                self.client_training_results
+                client_training_results=self.client_training_results
                 )
 
 

--- a/fedscale/cloud/aggregation/optimizers.py
+++ b/fedscale/cloud/aggregation/optimizers.py
@@ -46,8 +46,8 @@ class TorchServerOptimizer(object):
             Sashank J. Reddi, Zachary Charles, Manzil Zaheer, Zachary Garrett, Keith Rush, Jakub Konecný, Sanjiv Kumar, H. Brendan McMahan,
             ICLR 2021.
             """
-            last_model = [x.to(device=self.device) for x in last_model]
-            current_model = [x.to(device=self.device) for x in current_model]
+            # last_model = [x.to(device=self.device) for x in last_model]
+            # current_model = [x.to(device=self.device) for x in current_model]
 
             diff_weight = self.gradient_controller.update(
                 [pb - pa for pa, pb in zip(last_model, current_model)]
@@ -75,12 +75,14 @@ class TorchServerOptimizer(object):
                 update_weights = result["update_weight"]
                 if type(update_weights) is dict:
                     update_weights = [x for x in update_weights.values()]
-                weights = [torch.tensor(x).to(device=self.device) for x in update_weights]
+                weights = [
+                    torch.from_numpy(np.asarray(x, dtype=np.float32)).to(
+                        device=self.device
+                    )
+                    for x in update_weights
+                ]
                 grads = [
-                    (u - v)
-                    * 1.0
-                    / learning_rate
-                    for u, v in zip(last_model, weights)
+                    (u - v) * 1.0 / learning_rate for u, v in zip(last_model, weights)
                 ]
                 loss = result["moving_loss"]
 

--- a/fedscale/cloud/aggregation/optimizers.py
+++ b/fedscale/cloud/aggregation/optimizers.py
@@ -1,8 +1,10 @@
-import numpy as np 
+import numpy as np
 import torch
+
+
 class TorchServerOptimizer(object):
     """This is a abstract server optimizer class
-    
+
     Args:
         mode (string): mode of gradient aggregation policy
         args (distionary): Variable arguments for fedscale runtime config. defaults to the setup in arg_parser.py
@@ -10,29 +12,37 @@ class TorchServerOptimizer(object):
         sample_seed (int): Random seed
 
     """
-    def __init__(self, mode, args, device, sample_seed=233):
 
+    def __init__(self, mode, args, device, sample_seed=233):
         self.mode = mode
         self.args = args
         self.device = device
 
-        if mode == 'fed-yogi':
+        if mode == "fed-yogi":
             from fedscale.utils.optimizer.yogi import YoGi
-            self.gradient_controller = YoGi(
-                eta=args.yogi_eta, tau=args.yogi_tau, beta=args.yogi_beta, beta2=args.yogi_beta2)
 
-    def update_round_gradient(self, last_model, current_model, target_model):
-        """ update global model based on different policy
-        
+            self.gradient_controller = YoGi(
+                eta=args.yogi_eta,
+                tau=args.yogi_tau,
+                beta=args.yogi_beta,
+                beta2=args.yogi_beta2,
+            )
+
+    def update_round_gradient(
+        self, last_model, current_model, target_model, client_training_results=None
+    ):
+        """update global model based on different policy
+
         Args:
             last_model (list of tensor weight): A list of global model weight in last round.
             current_model (list of tensor weight): A list of global model weight in this round.
             target_model (PyTorch or TensorFlow nn module): Aggregated model.
-        
+            client_training_results list of gradients from every clients, for q-fedavg
+
         """
-        if self.mode == 'fed-yogi':
+        if self.mode == "fed-yogi":
             """
-            "Adaptive Federated Optimizations", 
+            "Adaptive Federated Optimizations",
             Sashank J. Reddi, Zachary Charles, Manzil Zaheer, Zachary Garrett, Keith Rush, Jakub Konecný, Sanjiv Kumar, H. Brendan McMahan,
             ICLR 2021.
             """
@@ -40,44 +50,52 @@ class TorchServerOptimizer(object):
             current_model = [x.to(device=self.device) for x in current_model]
 
             diff_weight = self.gradient_controller.update(
-                [pb-pa for pa, pb in zip(last_model, current_model)])
+                [pb - pa for pa, pb in zip(last_model, current_model)]
+            )
 
             new_state_dict = {
-                name: torch.from_numpy(np.array(last_model[idx] + diff_weight[idx], dtype=np.float32))
+                name: torch.from_numpy(
+                    np.array(last_model[idx] + diff_weight[idx], dtype=np.float32)
+                )
                 for idx, name in enumerate(target_model.state_dict().keys())
             }
 
             target_model.load_state_dict(new_state_dict)
 
-        elif self.mode == 'q-fedavg':
+        elif self.mode == "q-fedavg":
             """
             "Fair Resource Allocation in Federated Learning", Tian Li, Maziar Sanjabi, Ahmad Beirami, Virginia Smith, ICLR 2020.
             """
             learning_rate, qfedq = self.args.learning_rate, self.args.qfed_q
-            Deltas, hs = None, 0.
+            Deltas, hs = None, 0.0
             last_model = [x.to(device=self.device) for x in last_model]
 
-            for result in self.client_training_results:
+            for result in client_training_results:
                 # plug in the weight updates into the gradient
-                grads = [(u - torch.from_numpy(v).to(device=self.device)) * 1.0 /
-                         learning_rate for u, v in zip(last_model, result['update_weight'])]
-                loss = result['moving_loss']
+                grads = [
+                    (u - torch.from_numpy(v).to(device=self.device))
+                    * 1.0
+                    / learning_rate
+                    for u, v in zip(last_model, result["update_weight"])
+                ]
+                loss = result["moving_loss"]
 
                 if Deltas is None:
-                    Deltas = [np.float_power(
-                        loss+1e-10, qfedq) * grad for grad in grads]
+                    Deltas = [
+                        np.float_power(loss + 1e-10, qfedq) * grad for grad in grads
+                    ]
                 else:
                     for idx in range(len(Deltas)):
-                        Deltas[idx] += np.float_power(loss +
-                                                      1e-10, qfedq) * grads[idx]
+                        Deltas[idx] += np.float_power(loss + 1e-10, qfedq) * grads[idx]
 
                 # estimation of the local Lipchitz constant
-                hs += (qfedq * np.float_power(loss+1e-10, (qfedq-1)) * torch.sum(torch.stack([torch.square(
-                    grad).sum() for grad in grads])) + (1.0/learning_rate) * np.float_power(loss+1e-10, qfedq))
+                hs += qfedq * np.float_power(loss + 1e-10, (qfedq - 1)) * torch.sum(
+                    torch.stack([torch.square(grad).sum() for grad in grads])
+                ) + (1.0 / learning_rate) * np.float_power(loss + 1e-10, qfedq)
 
             # update global model
             for idx, param in enumerate(target_model.parameters()):
-                param.data = last_model[idx] - Deltas[idx]/(hs+1e-10)
+                param.data = last_model[idx] - Deltas[idx] / (hs + 1e-10)
 
         else:
             # The default optimizer, FedAvg, has been applied in aggregator.py on the fly

--- a/fedscale/cloud/aggregation/optimizers.py
+++ b/fedscale/cloud/aggregation/optimizers.py
@@ -76,7 +76,7 @@ class TorchServerOptimizer(object):
                     (u - torch.from_numpy(v).to(device=self.device))
                     * 1.0
                     / learning_rate
-                    for u, v in zip(last_model, result["update_weight"])
+                    for u, v in zip(last_model, result["update_weight"].values())
                 ]
                 loss = result["moving_loss"]
 

--- a/fedscale/cloud/aggregation/optimizers.py
+++ b/fedscale/cloud/aggregation/optimizers.py
@@ -46,8 +46,8 @@ class TorchServerOptimizer(object):
             Sashank J. Reddi, Zachary Charles, Manzil Zaheer, Zachary Garrett, Keith Rush, Jakub Konecný, Sanjiv Kumar, H. Brendan McMahan,
             ICLR 2021.
             """
-            # last_model = [x.to(device=self.device) for x in last_model]
-            # current_model = [x.to(device=self.device) for x in current_model]
+            last_model = [x.to(device=self.device) for x in last_model]
+            current_model = [x.to(device=self.device) for x in current_model]
 
             diff_weight = self.gradient_controller.update(
                 [pb - pa for pa, pb in zip(last_model, current_model)]

--- a/fedscale/cloud/aggregation/optimizers.py
+++ b/fedscale/cloud/aggregation/optimizers.py
@@ -72,11 +72,15 @@ class TorchServerOptimizer(object):
 
             for result in client_training_results:
                 # plug in the weight updates into the gradient
+                update_weights = result["update_weights"]
+                if type(update_weights) is dict:
+                    update_weights = [x for x in update_weights.values()]
+                weights = [torch.tensor(x).to(device=self.device) for x in update_weights]
                 grads = [
-                    (u - torch.from_numpy(v).to(device=self.device))
+                    (u - v)
                     * 1.0
                     / learning_rate
-                    for u, v in zip(last_model, result["update_weight"].values())
+                    for u, v in zip(last_model, weights)
                 ]
                 loss = result["moving_loss"]
 

--- a/fedscale/cloud/aggregation/optimizers.py
+++ b/fedscale/cloud/aggregation/optimizers.py
@@ -72,7 +72,7 @@ class TorchServerOptimizer(object):
 
             for result in client_training_results:
                 # plug in the weight updates into the gradient
-                update_weights = result["update_weights"]
+                update_weights = result["update_weight"]
                 if type(update_weights) is dict:
                     update_weights = [x for x in update_weights.values()]
                 weights = [torch.tensor(x).to(device=self.device) for x in update_weights]

--- a/fedscale/cloud/config_parser.py
+++ b/fedscale/cloud/config_parser.py
@@ -3,125 +3,137 @@ import argparse
 from fedscale.cloud import commons
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--job_name', type=str, default='demo_job')
-parser.add_argument('--log_path', type=str, default='./',
-                    help="default path is ../log")
-parser.add_argument('--wandb_token', type=str, default="",
-                    help="API key for wandb as login credentials")
+parser.add_argument("--job_name", type=str, default="demo_job")
+parser.add_argument("--log_path", type=str, default="./", help="default path is ../log")
+parser.add_argument(
+    "--wandb_token", type=str, default="", help="API key for wandb as login credentials"
+)
 
 # The basic configuration of the cluster
-parser.add_argument('--ps_ip', type=str, default='127.0.0.1')
-parser.add_argument('--ps_port', type=str, default='29500')
-parser.add_argument('--this_rank', type=int, default=1)
-parser.add_argument('--connection_timeout', type=int, default=60)
-parser.add_argument('--experiment_mode', type=str,
-                    default=commons.SIMULATION_MODE)
-parser.add_argument('--engine', type=str, default=commons.PYTORCH,
-                    help="Tensorflow or Pytorch for cloud aggregation")
-parser.add_argument('--num_executors', type=int, default=1)
-parser.add_argument('--executor_configs', type=str,
-                    default="127.0.0.1:[1]")  # seperated by ;
+parser.add_argument("--ps_ip", type=str, default="127.0.0.1")
+parser.add_argument("--ps_port", type=str, default="29500")
+parser.add_argument("--this_rank", type=int, default=1)
+parser.add_argument("--connection_timeout", type=int, default=60)
+parser.add_argument("--experiment_mode", type=str, default=commons.SIMULATION_MODE)
+parser.add_argument(
+    "--engine",
+    type=str,
+    default=commons.PYTORCH,
+    help="Tensorflow or Pytorch for cloud aggregation",
+)
+parser.add_argument("--num_executors", type=int, default=1)
+parser.add_argument(
+    "--executor_configs", type=str, default="127.0.0.1:[1]"
+)  # seperated by ;
 # Note: In async mode, the num_participants param is treated as the async buffer size. In sync, this is the number
 # of clients that are selected each round.
-parser.add_argument('--num_participants', type=int, default=4)
-parser.add_argument('--data_map_file', type=str, default=None)
-parser.add_argument('--use_cuda', type=str, default='True')
-parser.add_argument('--cuda_device', type=str, default=None)
-parser.add_argument('--time_stamp', type=str, default='logs')
-parser.add_argument('--task', type=str, default='cv')
-parser.add_argument('--device_avail_file', type=str, default=None)
-parser.add_argument('--clock_factor', type=float, default=1.0,
-                    help="Refactor the clock time given the profile")
+parser.add_argument("--num_participants", type=int, default=4)
+parser.add_argument("--data_map_file", type=str, default=None)
+parser.add_argument("--use_cuda", type=str, default="True")
+parser.add_argument("--cuda_device", type=str, default=None)
+parser.add_argument("--time_stamp", type=str, default="logs")
+parser.add_argument("--task", type=str, default="cv")
+parser.add_argument("--device_avail_file", type=str, default=None)
+parser.add_argument(
+    "--clock_factor",
+    type=float,
+    default=1.0,
+    help="Refactor the clock time given the profile",
+)
 
 # The configuration of model and dataset
-parser.add_argument('--model_zoo', type=str, default='torchcv',
-                    help="model zoo to load the models from", choices=["torchcv", "fedscale-torch-zoo",
-                                                                       "fedscale-tensorflow-zoo"])
-parser.add_argument('--data_dir', type=str, default='~/cifar10/')
-parser.add_argument('--device_conf_file', type=str, default='/tmp/client.cfg')
-parser.add_argument('--model', type=str, default='shufflenet_v2_x2_0')
-parser.add_argument('--data_set', type=str, default='cifar10')
-parser.add_argument('--sample_mode', type=str, default='random')
-parser.add_argument('--filter_less', type=int, default=32)
-parser.add_argument('--filter_more', type=int, default=1e15)
-parser.add_argument('--train_uniform', type=bool, default=False)
-parser.add_argument('--conf_path', type=str, default='~/dataset/')
-parser.add_argument('--overcommitment', type=float, default=1.3)
-parser.add_argument('--model_size', type=float, default=65536)
-parser.add_argument('--round_threshold', type=float, default=30)
-parser.add_argument('--round_penalty', type=float, default=2.0)
-parser.add_argument('--clip_bound', type=float, default=0.9)
-parser.add_argument('--blacklist_rounds', type=int, default=-1)
-parser.add_argument('--blacklist_max_len', type=float, default=0.3)
-parser.add_argument('--embedding_file', type=str,
-                    default='glove.840B.300d.txt')
-parser.add_argument('--input_shape', type=int, nargs='+', default=[1, 3, 28, 28])
-parser.add_argument('--save_checkpoint', type=bool, default=False)
+parser.add_argument(
+    "--model_zoo",
+    type=str,
+    default="torchcv",
+    help="model zoo to load the models from",
+    choices=["torchcv", "fedscale-torch-zoo", "fedscale-tensorflow-zoo"],
+)
+parser.add_argument("--data_dir", type=str, default="~/cifar10/")
+parser.add_argument("--device_conf_file", type=str, default="/tmp/client.cfg")
+parser.add_argument("--model", type=str, default="shufflenet_v2_x2_0")
+parser.add_argument("--data_set", type=str, default="cifar10")
+parser.add_argument("--sample_mode", type=str, default="random")
+parser.add_argument("--filter_less", type=int, default=32)
+parser.add_argument("--filter_more", type=int, default=1e15)
+parser.add_argument("--train_uniform", type=bool, default=False)
+parser.add_argument("--conf_path", type=str, default="~/dataset/")
+parser.add_argument("--overcommitment", type=float, default=1.3)
+parser.add_argument("--model_size", type=float, default=65536)
+parser.add_argument("--round_threshold", type=float, default=30)
+parser.add_argument("--round_penalty", type=float, default=2.0)
+parser.add_argument("--clip_bound", type=float, default=0.9)
+parser.add_argument("--blacklist_rounds", type=int, default=-1)
+parser.add_argument("--blacklist_max_len", type=float, default=0.3)
+parser.add_argument("--embedding_file", type=str, default="glove.840B.300d.txt")
+parser.add_argument("--input_shape", type=int, nargs="+", default=[1, 3, 28, 28])
+parser.add_argument("--save_checkpoint", type=bool, default=False)
 
 
 # The configuration of different hyper-parameters for training
-parser.add_argument('--rounds', type=int, default=50)
-parser.add_argument('--local_steps', type=int, default=20)
-parser.add_argument('--batch_size', type=int, default=30)
-parser.add_argument('--test_bsz', type=int, default=128)
-parser.add_argument('--backend', type=str, default="gloo")
-parser.add_argument('--learning_rate', type=float, default=5e-2)
-parser.add_argument('--min_learning_rate', type=float, default=5e-5)
-parser.add_argument('--input_dim', type=int, default=0)
-parser.add_argument('--output_dim', type=int, default=0)
-parser.add_argument('--dump_epoch', type=int, default=1e10)
-parser.add_argument('--decay_factor', type=float, default=0.98)
-parser.add_argument('--decay_round', type=float, default=10)
-parser.add_argument('--num_loaders', type=int, default=2)
-parser.add_argument('--eval_interval', type=int, default=5)
-parser.add_argument('--sample_seed', type=int, default=233)  # 123 #233
-parser.add_argument('--test_ratio', type=float, default=1.0)
-parser.add_argument('--loss_decay', type=float, default=0.2)
-parser.add_argument('--exploration_min', type=float, default=0.3)
-parser.add_argument('--cut_off_util', type=float,
-                    default=0.05)  # 95 percentile
+parser.add_argument("--rounds", type=int, default=50)
+parser.add_argument("--local_steps", type=int, default=20)
+parser.add_argument("--batch_size", type=int, default=30)
+parser.add_argument("--test_bsz", type=int, default=128)
+parser.add_argument("--backend", type=str, default="gloo")
+parser.add_argument("--learning_rate", type=float, default=5e-2)
+parser.add_argument("--min_learning_rate", type=float, default=5e-5)
+parser.add_argument("--input_dim", type=int, default=0)
+parser.add_argument("--output_dim", type=int, default=0)
+parser.add_argument("--dump_epoch", type=int, default=1e10)
+parser.add_argument("--decay_factor", type=float, default=0.98)
+parser.add_argument("--decay_round", type=float, default=10)
+parser.add_argument("--num_loaders", type=int, default=2)
+parser.add_argument("--eval_interval", type=int, default=5)
+parser.add_argument("--sample_seed", type=int, default=233)  # 123 #233
+parser.add_argument("--test_ratio", type=float, default=1.0)
+parser.add_argument("--loss_decay", type=float, default=0.2)
+parser.add_argument("--exploration_min", type=float, default=0.3)
+parser.add_argument("--cut_off_util", type=float, default=0.05)  # 95 percentile
 
-parser.add_argument('--gradient_policy', type=str, default=None)
+parser.add_argument("--gradient_policy", type=str, default=None)
 
 # for yogi
-parser.add_argument('--yogi_eta', type=float, default=3e-3)
-parser.add_argument('--yogi_tau', type=float, default=1e-8)
-parser.add_argument('--yogi_beta', type=float, default=0.9)
-parser.add_argument('--yogi_beta2', type=float, default=0.99)
+parser.add_argument("--yogi_eta", type=float, default=3e-3)
+parser.add_argument("--yogi_tau", type=float, default=1e-8)
+parser.add_argument("--yogi_beta", type=float, default=0.9)
+parser.add_argument("--yogi_beta2", type=float, default=0.99)
+
+# for q-fedavg
+parser.add_argument("--qfed_q", type=float, default=1.0)
 
 
 # for prox
-parser.add_argument('--proxy_mu', type=float, default=0.1)
+parser.add_argument("--proxy_mu", type=float, default=0.1)
 
 # for detection
-parser.add_argument('--cfg_file', type=str,
-                    default='./utils/rcnn/cfgs/res101.yml')
-parser.add_argument('--test_output_dir', type=str, default='./logs/server')
-parser.add_argument('--train_size_file', type=str, default='')
-parser.add_argument('--test_size_file', type=str, default='')
-parser.add_argument('--data_cache', type=str, default='')
-parser.add_argument('--backbone', type=str, default='./resnet50.pth')
+parser.add_argument("--cfg_file", type=str, default="./utils/rcnn/cfgs/res101.yml")
+parser.add_argument("--test_output_dir", type=str, default="./logs/server")
+parser.add_argument("--train_size_file", type=str, default="")
+parser.add_argument("--test_size_file", type=str, default="")
+parser.add_argument("--data_cache", type=str, default="")
+parser.add_argument("--backbone", type=str, default="./resnet50.pth")
 
 
 # for malicious
-parser.add_argument('--malicious_factor', type=int, default=1e15)
+parser.add_argument("--malicious_factor", type=int, default=1e15)
 
 # for asynchronous FL
-parser.add_argument('--max_concurrency', type=int, default=10)
-parser.add_argument('--max_staleness', type=int, default=5)
+parser.add_argument("--max_concurrency", type=int, default=10)
+parser.add_argument("--max_staleness", type=int, default=5)
 
 # for differential privacy
-parser.add_argument('--noise_factor', type=float, default=0.1)
-parser.add_argument('--clip_threshold', type=float, default=3.0)
-parser.add_argument('--target_delta', type=float, default=0.0001)
+parser.add_argument("--noise_factor", type=float, default=0.1)
+parser.add_argument("--clip_threshold", type=float, default=3.0)
+parser.add_argument("--target_delta", type=float, default=0.0001)
 
 # for Oort
-parser.add_argument('--pacer_delta', type=float, default=5)
-parser.add_argument('--pacer_step', type=int, default=20)
-parser.add_argument('--exploration_alpha', type=float, default=0.3)
-parser.add_argument('--exploration_factor', type=float, default=0.9)
-parser.add_argument('--exploration_decay', type=float, default=0.98)
-parser.add_argument('--sample_window', type=float, default=5.0)
+parser.add_argument("--pacer_delta", type=float, default=5)
+parser.add_argument("--pacer_step", type=int, default=20)
+parser.add_argument("--exploration_alpha", type=float, default=0.3)
+parser.add_argument("--exploration_factor", type=float, default=0.9)
+parser.add_argument("--exploration_decay", type=float, default=0.98)
+parser.add_argument("--sample_window", type=float, default=5.0)
 
 # for albert
 parser.add_argument(
@@ -129,17 +141,26 @@ parser.add_argument(
     action="store_true",
     help="Whether distinct lines of text in the dataset are to be handled as distinct sequences.",
 )
-parser.add_argument('--clf_block_size', type=int, default=32)
+parser.add_argument("--clf_block_size", type=int, default=32)
 
 
 parser.add_argument(
-    "--mlm", type=bool, default=False, help="Train with masked-language modeling loss instead of language modeling."
+    "--mlm",
+    type=bool,
+    default=False,
+    help="Train with masked-language modeling loss instead of language modeling.",
 )
 parser.add_argument(
-    "--mlm_probability", type=float, default=0.15, help="Ratio of tokens to mask for masked language modeling loss"
+    "--mlm_probability",
+    type=float,
+    default=0.15,
+    help="Ratio of tokens to mask for masked language modeling loss",
 )
 parser.add_argument(
-    "--overwrite_cache", type=bool, default=False, help="Overwrite the cached training and evaluation sets"
+    "--overwrite_cache",
+    type=bool,
+    default=False,
+    help="Overwrite the cached training and evaluation sets",
 )
 parser.add_argument(
     "--block_size",
@@ -151,83 +172,143 @@ parser.add_argument(
 )
 
 
-parser.add_argument("--weight_decay", default=0, type=float,
-                    help="Weight decay if we apply some.")
-parser.add_argument("--adam_epsilon", default=1e-8,
-                    type=float, help="Epsilon for Adam optimizer.")
+parser.add_argument(
+    "--weight_decay", default=0, type=float, help="Weight decay if we apply some."
+)
+parser.add_argument(
+    "--adam_epsilon", default=1e-8, type=float, help="Epsilon for Adam optimizer."
+)
 
 # for tag prediction
-parser.add_argument("--vocab_token_size", type=int,
-                    default=10000, help="For vocab token size")
-parser.add_argument("--vocab_tag_size", type=int,
-                    default=500, help="For vocab tag size")
+parser.add_argument(
+    "--vocab_token_size", type=int, default=10000, help="For vocab token size"
+)
+parser.add_argument(
+    "--vocab_tag_size", type=int, default=500, help="For vocab tag size"
+)
 
 # for rl example
 parser.add_argument("--epsilon", type=float, default=0.9, help="greedy policy")
 parser.add_argument("--gamma", type=float, default=0.9, help="reward discount")
-parser.add_argument("--memory_capacity", type=int,
-                    default=2000, help="memory capacity")
-parser.add_argument("--target_replace_iter", type=int,
-                    default=15, help="update frequency")
+parser.add_argument("--memory_capacity", type=int, default=2000, help="memory capacity")
+parser.add_argument(
+    "--target_replace_iter", type=int, default=15, help="update frequency"
+)
 parser.add_argument("--n_actions", type=int, default=2, help="action number")
 parser.add_argument("--n_states", type=int, default=4, help="state number")
 
 
-parser.add_argument("--num_classes", type=int, default=35,
-                    help="For number of classes of the dataset")
+parser.add_argument(
+    "--num_classes", type=int, default=35, help="For number of classes of the dataset"
+)
 
 
 # for voice
-parser.add_argument('--train-manifest', metavar='DIR',
-                    help='path to train manifest csv', default='data/train_manifest.csv')
-parser.add_argument('--test-manifest', metavar='DIR',
-                    help='path to test manifest csv', default='data/test_manifest.csv')
-parser.add_argument('--sample-rate', default=16000,
-                    type=int, help='Sample rate')
-parser.add_argument('--labels-path', default='labels.json',
-                    help='Contains all characters for transcription')
-parser.add_argument('--window-size', default=.02, type=float,
-                    help='Window size for spectrogram in seconds')
-parser.add_argument('--window-stride', default=.01, type=float,
-                    help='Window stride for spectrogram in seconds')
-parser.add_argument('--window', default='hamming',
-                    help='Window type for spectrogram generation')
-parser.add_argument('--hidden-size', default=256,
-                    type=int, help='Hidden size of RNNs')
-parser.add_argument('--hidden-layers', default=7,
-                    type=int, help='Number of RNN layers')
-parser.add_argument('--rnn-type', default='lstm',
-                    help='Type of the RNN. rnn|gru|lstm are supported')
-parser.add_argument('--finetune', dest='finetune', action='store_true',
-                    help='Finetune the model from checkpoint "continue_from"')
-parser.add_argument('--speed-volume-perturb', dest='speed_volume_perturb', action='store_true',
-                    help='Use random tempo and gain perturbations.')
-parser.add_argument('--spec-augment', dest='spec_augment', action='store_true',
-                    help='Use simple spectral augmentation on mel spectograms.')
-parser.add_argument('--noise-dir', default=None,
-                    help='Directory to inject noise into audio. If default, noise Inject not added')
-parser.add_argument('--noise-prob', default=0.4,
-                    help='Probability of noise being added per sample')
-parser.add_argument('--noise-min', default=0.0,
-                    help='Minimum noise level to sample from. (1.0 means all noise, not original signal)', type=float)
-parser.add_argument('--noise-max', default=0.5,
-                    help='Maximum noise levels to sample from. Maximum 1.0', type=float)
-parser.add_argument('--no-bidirectional', dest='bidirectional', action='store_false', default=True,
-                    help='Turn off bi-directional RNNs, introduces lookahead convolution')
+parser.add_argument(
+    "--train-manifest",
+    metavar="DIR",
+    help="path to train manifest csv",
+    default="data/train_manifest.csv",
+)
+parser.add_argument(
+    "--test-manifest",
+    metavar="DIR",
+    help="path to test manifest csv",
+    default="data/test_manifest.csv",
+)
+parser.add_argument("--sample-rate", default=16000, type=int, help="Sample rate")
+parser.add_argument(
+    "--labels-path",
+    default="labels.json",
+    help="Contains all characters for transcription",
+)
+parser.add_argument(
+    "--window-size",
+    default=0.02,
+    type=float,
+    help="Window size for spectrogram in seconds",
+)
+parser.add_argument(
+    "--window-stride",
+    default=0.01,
+    type=float,
+    help="Window stride for spectrogram in seconds",
+)
+parser.add_argument(
+    "--window", default="hamming", help="Window type for spectrogram generation"
+)
+parser.add_argument("--hidden-size", default=256, type=int, help="Hidden size of RNNs")
+parser.add_argument("--hidden-layers", default=7, type=int, help="Number of RNN layers")
+parser.add_argument(
+    "--rnn-type", default="lstm", help="Type of the RNN. rnn|gru|lstm are supported"
+)
+parser.add_argument(
+    "--finetune",
+    dest="finetune",
+    action="store_true",
+    help='Finetune the model from checkpoint "continue_from"',
+)
+parser.add_argument(
+    "--speed-volume-perturb",
+    dest="speed_volume_perturb",
+    action="store_true",
+    help="Use random tempo and gain perturbations.",
+)
+parser.add_argument(
+    "--spec-augment",
+    dest="spec_augment",
+    action="store_true",
+    help="Use simple spectral augmentation on mel spectograms.",
+)
+parser.add_argument(
+    "--noise-dir",
+    default=None,
+    help="Directory to inject noise into audio. If default, noise Inject not added",
+)
+parser.add_argument(
+    "--noise-prob", default=0.4, help="Probability of noise being added per sample"
+)
+parser.add_argument(
+    "--noise-min",
+    default=0.0,
+    help="Minimum noise level to sample from. (1.0 means all noise, not original signal)",
+    type=float,
+)
+parser.add_argument(
+    "--noise-max",
+    default=0.5,
+    help="Maximum noise levels to sample from. Maximum 1.0",
+    type=float,
+)
+parser.add_argument(
+    "--no-bidirectional",
+    dest="bidirectional",
+    action="store_false",
+    default=True,
+    help="Turn off bi-directional RNNs, introduces lookahead convolution",
+)
 
 args, unknown = parser.parse_known_args()
 args.use_cuda = eval(args.use_cuda)
 
 
-datasetCategories = {'Mnist': 10, 'cifar10': 10, "imagenet": 1000, 'emnist': 47,
-                     'openImg': 596, 'google_speech': 35, 'femnist': 62, 'yelp': 5
-                     }
+datasetCategories = {
+    "Mnist": 10,
+    "cifar10": 10,
+    "imagenet": 1000,
+    "emnist": 47,
+    "openImg": 596,
+    "google_speech": 35,
+    "femnist": 62,
+    "yelp": 5,
+}
 
 # Profiled relative speech w.r.t. Mobilenet
-model_factor = {'shufflenet': 0.0644/0.0554,
-                'albert': 0.335/0.0554,
-                'resnet': 0.135/0.0554,
-                }
+model_factor = {
+    "shufflenet": 0.0644 / 0.0554,
+    "albert": 0.335 / 0.0554,
+    "resnet": 0.135 / 0.0554,
+}
 
 args.num_class = datasetCategories.get(args.data_set, args.num_classes)
 for model_name in model_factor:

--- a/fedscale/cloud/execution/executor.py
+++ b/fedscale/cloud/execution/executor.py
@@ -397,7 +397,7 @@ class Executor(object):
 
                 elif current_event == commons.UPDATE_MODEL:
                     model_weights = self.deserialize_response(request.data)
-                    self.UpdateModel(model_weights)
+                    self.UpdateModel(model_weights, is_aggregator=False)
 
                 elif current_event == commons.SHUT_DOWN:
                     self.Stop()

--- a/fedscale/cloud/execution/executor.py
+++ b/fedscale/cloud/execution/executor.py
@@ -33,7 +33,9 @@ class Executor(object):
         # initiate the executor log path, and executor ips
         logger.initiate_client_setting()
 
-        self.model_adapter = self.get_client_trainer(args).get_model_adapter(init_model())
+        self.model_adapter = self.get_client_trainer(args).get_model_adapter(
+            init_model()
+        )
 
         self.args = args
         self.num_executors = args.num_executors
@@ -45,8 +47,7 @@ class Executor(object):
         self.training_sets = self.test_dataset = None
 
         # ======== channels ========
-        self.aggregator_communicator = ClientConnections(
-            args.ps_ip, args.ps_port)
+        self.aggregator_communicator = ClientConnections(args.ps_ip, args.ps_port)
 
         # ======== runtime information ========
         self.collate_fn = None
@@ -56,28 +57,28 @@ class Executor(object):
         self.event_queue = collections.deque()
 
         if args.wandb_token != "":
-            os.environ['WANDB_API_KEY'] = args.wandb_token
+            os.environ["WANDB_API_KEY"] = args.wandb_token
             self.wandb = wandb
             if self.wandb.run is None:
-                self.wandb.init(project=f'fedscale-{args.job_name}',
-                                name=f'executor{args.this_rank}-{args.time_stamp}',
-                                group=f'{args.time_stamp}')
+                self.wandb.init(
+                    project=f"fedscale-{args.job_name}",
+                    name=f"executor{args.this_rank}-{args.time_stamp}",
+                    group=f"{args.time_stamp}",
+                )
             else:
                 logging.error("Warning: wandb has already been initialized")
-            
+
         else:
             self.wandb = None
         super(Executor, self).__init__()
 
     def setup_env(self):
-        """Set up experiments environment
-        """
+        """Set up experiments environment"""
         logging.info(f"(EXECUTOR:{self.this_rank}) is setting up environ ...")
         self.setup_seed(seed=1)
 
     def setup_communication(self):
-        """Set up grpc connection
-        """
+        """Set up grpc connection"""
         self.init_control_communication()
         self.init_data_communication()
 
@@ -101,8 +102,7 @@ class Executor(object):
         self.aggregator_communicator.connect_to_server()
 
     def init_data_communication(self):
-        """In charge of jumbo data traffics (e.g., fetch training result)
-        """
+        """In charge of jumbo data traffics (e.g., fetch training result)"""
         pass
 
     def init_data(self):
@@ -115,20 +115,27 @@ class Executor(object):
         train_dataset, test_dataset = init_dataset()
         if self.args.task == "rl":
             return train_dataset, test_dataset
-        if self.args.task == 'nlp':
+        if self.args.task == "nlp":
             self.collate_fn = collate
-        elif self.args.task == 'voice':
+        elif self.args.task == "voice":
             self.collate_fn = voice_collate_fn
         # load data partitionxr (entire_train_data)
         logging.info("Data partitioner starts ...")
 
         training_sets = DataPartitioner(
-            data=train_dataset, args=self.args, numOfClass=self.args.num_class)
+            data=train_dataset, args=self.args, numOfClass=self.args.num_class
+        )
         training_sets.partition_data_helper(
-            num_clients=self.args.num_participants, data_map_file=self.args.data_map_file)
+            num_clients=self.args.num_participants,
+            data_map_file=self.args.data_map_file,
+        )
 
         testing_sets = DataPartitioner(
-            data=test_dataset, args=self.args, numOfClass=self.args.num_class, isTest=True)
+            data=test_dataset,
+            args=self.args,
+            numOfClass=self.args.num_class,
+            isTest=True,
+        )
         testing_sets.partition_data_helper(num_clients=self.num_executors)
 
         logging.info("Data partitioner completes ...")
@@ -136,8 +143,7 @@ class Executor(object):
         return training_sets, testing_sets
 
     def run(self):
-        """Start running the executor by setting up execution and communication environment, and monitoring the grpc message.
-        """
+        """Start running the executor by setting up execution and communication environment, and monitoring the grpc message."""
         self.setup_env()
         self.training_sets, self.testing_sets = self.init_data()
         self.setup_communication()
@@ -184,7 +190,7 @@ class Executor(object):
 
         """
         self.round += 1
-        self.model_adapter.set_weights(model_weights)
+        self.model_adapter.set_weights(model_weights, is_aggregator=False)
 
     def Train(self, config):
         """Load train config and data to start training on that client
@@ -196,20 +202,25 @@ class Executor(object):
             tuple (int, dictionary): The client id and train result
 
         """
-        client_id, train_config = config['client_id'], config['task_config']
+        client_id, train_config = config["client_id"], config["task_config"]
 
-        if 'model' not in config or not config['model']:
+        if "model" not in config or not config["model"]:
             raise "The 'model' object must be a non-null value in the training config."
         client_conf = self.override_conf(train_config)
         train_res = self.training_handler(
-            client_id=client_id, conf=client_conf, model=config['model'])
+            client_id=client_id, conf=client_conf, model=config["model"]
+        )
 
         # Report execution completion meta information
         response = self.aggregator_communicator.stub.CLIENT_EXECUTE_COMPLETION(
             job_api_pb2.CompleteRequest(
-                client_id=str(client_id), executor_id=self.executor_id,
-                event=commons.CLIENT_TRAIN, status=True, msg=None,
-                meta_result=None, data_result=None
+                client_id=str(client_id),
+                executor_id=self.executor_id,
+                event=commons.CLIENT_TRAIN,
+                status=True,
+                msg=None,
+                meta_result=None,
+                data_result=None,
             )
         )
         self.dispatch_worker_events(response)
@@ -224,21 +235,24 @@ class Executor(object):
 
         """
         test_res = self.testing_handler()
-        test_res = {'executorId': self.this_rank, 'results': test_res}
+        test_res = {"executorId": self.this_rank, "results": test_res}
 
         # Report execution completion information
         response = self.aggregator_communicator.stub.CLIENT_EXECUTE_COMPLETION(
             job_api_pb2.CompleteRequest(
-                client_id=self.executor_id, executor_id=self.executor_id,
-                event=commons.MODEL_TEST, status=True, msg=None,
-                meta_result=None, data_result=self.serialize_response(test_res)
+                client_id=self.executor_id,
+                executor_id=self.executor_id,
+                event=commons.MODEL_TEST,
+                status=True,
+                msg=None,
+                meta_result=None,
+                data_result=self.serialize_response(test_res),
             )
         )
         self.dispatch_worker_events(response)
 
     def Stop(self):
-        """Stop the current executor
-        """
+        """Stop the current executor"""
         logging.info(f"Terminating the executor ...")
         self.aggregator_communicator.close_sever_connection()
         self.received_stop_request = True
@@ -255,7 +269,7 @@ class Executor(object):
         return self.training_sets.getSize()
 
     def override_conf(self, config):
-        """ Override the variable arguments for different client
+        """Override the variable arguments for different client
 
         Args:
             config (dictionary): The client runtime config.
@@ -280,7 +294,7 @@ class Executor(object):
         if conf.engine == commons.TENSORFLOW:
             return TensorflowClient(conf)
         elif conf.engine == commons.PYTORCH:
-            if conf.task == 'rl':
+            if conf.task == "rl":
                 return RLClient(conf)
             else:
                 return TorchClient(conf)
@@ -300,14 +314,21 @@ class Executor(object):
         self.model_adapter.set_weights(model)
         conf.client_id = client_id
         conf.tokenizer = tokenizer
-        client_data = self.training_sets if self.args.task == "rl" else \
-            select_dataset(client_id, self.training_sets,
-                           batch_size=conf.batch_size, args=self.args,
-                           collate_fn=self.collate_fn
-                           )
+        client_data = (
+            self.training_sets
+            if self.args.task == "rl"
+            else select_dataset(
+                client_id,
+                self.training_sets,
+                batch_size=conf.batch_size,
+                args=self.args,
+                collate_fn=self.collate_fn,
+            )
+        )
         client = self.get_client_trainer(self.args)
         train_res = client.train(
-            client_data=client_data, model=self.model_adapter.get_model(), conf=conf)
+            client_data=client_data, model=self.model_adapter.get_model(), conf=conf
+        )
 
         return train_res
 
@@ -321,25 +342,33 @@ class Executor(object):
             dictionary: The test result
 
         """
-        test_config = self.override_conf({
-            'rank': self.this_rank,
-            'memory_capacity': self.args.memory_capacity,
-            'tokenizer': tokenizer
-        })
+        test_config = self.override_conf(
+            {
+                "rank": self.this_rank,
+                "memory_capacity": self.args.memory_capacity,
+                "tokenizer": tokenizer,
+            }
+        )
         client = self.get_client_trainer(test_config)
-        data_loader = select_dataset(self.this_rank, self.testing_sets,
-                                     batch_size=self.args.test_bsz, args=self.args,
-                                     isTest=True, collate_fn=self.collate_fn)
+        data_loader = select_dataset(
+            self.this_rank,
+            self.testing_sets,
+            batch_size=self.args.test_bsz,
+            args=self.args,
+            isTest=True,
+            collate_fn=self.collate_fn,
+        )
 
-        test_results = client.test(data_loader, self.model_adapter.get_model(), test_config)
+        test_results = client.test(
+            data_loader, self.model_adapter.get_model(), test_config
+        )
         self.log_test_result(test_results)
         gc.collect()
 
         return test_results
 
     def client_register(self):
-        """Register the executor information to the aggregator
-        """
+        """Register the executor information to the aggregator"""
         start_time = time.time()
         while time.time() - start_time < 180:
             try:
@@ -348,27 +377,29 @@ class Executor(object):
                         client_id=self.executor_id,
                         executor_id=self.executor_id,
                         executor_info=self.serialize_response(
-                            self.report_executor_info_handler())
+                            self.report_executor_info_handler()
+                        ),
                     )
                 )
                 self.dispatch_worker_events(response)
                 break
             except Exception as e:
-                logging.warning(f"Failed to connect to aggregator {e}. Will retry in 5 sec.")
+                logging.warning(
+                    f"Failed to connect to aggregator {e}. Will retry in 5 sec."
+                )
                 time.sleep(5)
 
     def client_ping(self):
-        """Ping the aggregator for new task
-        """
-        response = self.aggregator_communicator.stub.CLIENT_PING(job_api_pb2.PingRequest(
-            client_id=self.executor_id,
-            executor_id=self.executor_id
-        ))
+        """Ping the aggregator for new task"""
+        response = self.aggregator_communicator.stub.CLIENT_PING(
+            job_api_pb2.PingRequest(
+                client_id=self.executor_id, executor_id=self.executor_id
+            )
+        )
         self.dispatch_worker_events(response)
 
     def event_monitor(self):
-        """Activate event handler once receiving new message
-        """
+        """Activate event handler once receiving new message"""
         logging.info("Start monitoring events ...")
         self.client_register()
 
@@ -380,24 +411,34 @@ class Executor(object):
                 if current_event == commons.CLIENT_TRAIN:
                     train_config = self.deserialize_response(request.meta)
                     train_model = self.deserialize_response(request.data)
-                    train_config['model'] = train_model
-                    train_config['client_id'] = int(train_config['client_id'])
+                    train_config["model"] = train_model
+                    train_config["client_id"] = int(train_config["client_id"])
                     client_id, train_res = self.Train(train_config)
 
                     # Upload model updates
                     future_call = self.aggregator_communicator.stub.CLIENT_EXECUTE_COMPLETION.future(
-                        job_api_pb2.CompleteRequest(client_id=str(client_id), executor_id=self.executor_id,
-                                                    event=commons.UPLOAD_MODEL, status=True, msg=None,
-                                                    meta_result=None, data_result=self.serialize_response(train_res)
-                                                    ))
-                    future_call.add_done_callback(lambda _response: self.dispatch_worker_events(_response.result()))
+                        job_api_pb2.CompleteRequest(
+                            client_id=str(client_id),
+                            executor_id=self.executor_id,
+                            event=commons.UPLOAD_MODEL,
+                            status=True,
+                            msg=None,
+                            meta_result=None,
+                            data_result=self.serialize_response(train_res),
+                        )
+                    )
+                    future_call.add_done_callback(
+                        lambda _response: self.dispatch_worker_events(
+                            _response.result()
+                        )
+                    )
 
                 elif current_event == commons.MODEL_TEST:
                     self.Test(self.deserialize_response(request.meta))
 
                 elif current_event == commons.UPDATE_MODEL:
                     model_weights = self.deserialize_response(request.data)
-                    self.UpdateModel(model_weights, is_aggregator=False)
+                    self.UpdateModel(model_weights)
 
                 elif current_event == commons.SHUT_DOWN:
                     self.Stop()
@@ -409,22 +450,26 @@ class Executor(object):
                 try:
                     self.client_ping()
                 except Exception as e:
-                    logging.info(f"Caught exception {e} from aggregator, terminating executor {self.this_rank} ...")
+                    logging.info(
+                        f"Caught exception {e} from aggregator, terminating executor {self.this_rank} ..."
+                    )
                     self.Stop()
 
-    
     def log_test_result(self, test_res):
-        """Log test results to wandb server if enabled
-        """
+        """Log test results to wandb server if enabled"""
         acc = round(test_res["top_1"] / test_res["test_len"], 4)
         acc_5 = round(test_res["top_5"] / test_res["test_len"], 4)
         test_loss = test_res["test_loss"] / test_res["test_len"]
         if self.wandb != None:
-            self.wandb.log({
-                'Test/round_to_top1_accuracy': acc,
-                'Test/round_to_top5_accuracy': acc_5,
-                'Test/round_to_loss': test_loss,
-            }, step=self.round)
+            self.wandb.log(
+                {
+                    "Test/round_to_top1_accuracy": acc,
+                    "Test/round_to_top5_accuracy": acc_5,
+                    "Test/round_to_loss": test_loss,
+                },
+                step=self.round,
+            )
+
 
 if __name__ == "__main__":
     executor = Executor(parser.args)

--- a/fedscale/cloud/execution/executor.py
+++ b/fedscale/cloud/execution/executor.py
@@ -311,7 +311,7 @@ class Executor(object):
             dictionary: The train result
 
         """
-        self.model_adapter.set_weights(model)
+        self.model_adapter.set_weights(model, is_aggregator=False)
         conf.client_id = client_id
         conf.tokenizer = tokenizer
         client_data = (

--- a/fedscale/cloud/internal/torch_model_adapter.py
+++ b/fedscale/cloud/internal/torch_model_adapter.py
@@ -20,10 +20,11 @@ class TorchModelAdapter(ModelAdapterBase):
         self.model = model
         self.optimizer = optimizer
 
-    def set_weights(self, weights: List[np.ndarray]):
+    def set_weights(self, weights: List[np.ndarray], is_aggregator=True):
         """
         Set the model's weights to the numpy weights array.
         :param weights: numpy weights array
+        :param is_aggregator: boolean indicating whether the caller is the aggregator
         """
         last_grad_weights = [param.data.clone() for param in self.model.state_dict().values()]
         new_state_dict = {
@@ -31,7 +32,7 @@ class TorchModelAdapter(ModelAdapterBase):
             for i, name in enumerate(self.model.state_dict().keys())
         }
         self.model.load_state_dict(new_state_dict)
-        if self.optimizer:
+        if self.optimizer and is_aggregator:
             weights_origin = copy.deepcopy(weights)
             weights = [torch.tensor(x) for x in weights_origin]
             self.optimizer.update_round_gradient(last_grad_weights, weights, self.model)

--- a/fedscale/cloud/internal/torch_model_adapter.py
+++ b/fedscale/cloud/internal/torch_model_adapter.py
@@ -20,11 +20,12 @@ class TorchModelAdapter(ModelAdapterBase):
         self.model = model
         self.optimizer = optimizer
 
-    def set_weights(self, weights: List[np.ndarray], is_aggregator=True):
+    def set_weights(self, weights: List[np.ndarray], is_aggregator=True, client_training_results=None):
         """
         Set the model's weights to the numpy weights array.
         :param weights: numpy weights array
         :param is_aggregator: boolean indicating whether the caller is the aggregator
+        :param client_training_results: list of gradients from every clients, for q-fedavg
         """
         last_grad_weights = [param.data.clone() for param in self.model.state_dict().values()]
         new_state_dict = {
@@ -35,7 +36,7 @@ class TorchModelAdapter(ModelAdapterBase):
         if self.optimizer and is_aggregator:
             weights_origin = copy.deepcopy(weights)
             weights = [torch.tensor(x) for x in weights_origin]
-            self.optimizer.update_round_gradient(last_grad_weights, weights, self.model)
+            self.optimizer.update_round_gradient(last_grad_weights, weights, self.model, client_training_results)
 
     def get_weights(self) -> List[np.ndarray]:
         """

--- a/fedscale/utils/optimizer/yogi.py
+++ b/fedscale/utils/optimizer/yogi.py
@@ -1,7 +1,8 @@
 import torch
 import numpy as np
 
-class YoGi():
+
+class YoGi:
     def __init__(self, eta=1e-2, tau=1e-3, beta=0.9, beta2=0.99):
         self.eta = eta
         self.tau = tau
@@ -14,19 +15,18 @@ class YoGi():
     def update(self, gradients):
         update_gradients = []
         if not self.v_t:
-            self.v_t = [ np.asarray([self.tau**2 for _ in g], dtype=np.float32) for g in gradients]
-            self.m_t = [ np.full(len(g), 0.0, dtype=np.float32) for g in gradients]
+            self.v_t = [np.full(len(g), self.tau**2, dtype=np.float32) for g in gradients]
+            self.m_t = [np.full(len(g), 0.0, dtype=np.float32) for g in gradients]
 
         for idx, gradient in enumerate(gradients):
             gradient_square = gradient**2
-            
-            self.m_t[idx] = self.beta * \
-                self.m_t[idx] + (1.-self.beta) * gradient
- 
-            self.v_t[idx] = self.v_t[idx] - (1.-self.beta2) * gradient_square * torch.sign(
-                self.v_t[idx] - gradient_square)
-            yogi_learning_rate = self.eta / \
-                (torch.sqrt(self.v_t[idx]) + self.tau)
+
+            self.m_t[idx] = self.beta * self.m_t[idx] + (1.0 - self.beta) * gradient
+
+            self.v_t[idx] = self.v_t[idx] - (
+                1.0 - self.beta2
+            ) * gradient_square * torch.sign(self.v_t[idx] - gradient_square)
+            yogi_learning_rate = self.eta / (torch.sqrt(self.v_t[idx]) + self.tau)
 
             update_gradients.append(yogi_learning_rate * self.m_t[idx])
 

--- a/fedscale/utils/optimizer/yogi.py
+++ b/fedscale/utils/optimizer/yogi.py
@@ -15,7 +15,7 @@ class YoGi:
     def update(self, gradients):
         update_gradients = []
         if not self.v_t:
-            self.v_t = [torch.full_like(g, self.tau**2) for g in gradients]
+            self.v_t = [g**2 for g in gradients]
             self.m_t = [torch.full_like(g, 0.0) for g in gradients]
 
         for idx, gradient in enumerate(gradients):

--- a/fedscale/utils/optimizer/yogi.py
+++ b/fedscale/utils/optimizer/yogi.py
@@ -1,5 +1,5 @@
 import torch
-
+import numpy as np
 
 class YoGi():
     def __init__(self, eta=1e-2, tau=1e-3, beta=0.9, beta2=0.99):
@@ -8,28 +8,27 @@ class YoGi():
         self.beta = beta
 
         self.v_t = []
-        self.delta_t = []
+        self.m_t = []
         self.beta2 = beta2
 
     def update(self, gradients):
         update_gradients = []
+        if not self.v_t:
+            self.v_t = [ np.asarray([self.tau**2 for _ in g], dtype=np.float32) for g in gradients]
+            self.m_t = [ np.full(len(g), 0.0, dtype=np.float32) for g in gradients]
+
         for idx, gradient in enumerate(gradients):
             gradient_square = gradient**2
-            if len(self.v_t) <= idx:
-                #gradient_square = gradient**2
-                self.v_t.append(gradient_square)
-                self.delta_t.append(gradient)
-            else:
-                # yogi
-                self.delta_t[idx] = self.beta * \
-                    self.delta_t[idx] + (1.-self.beta) * gradient
-                #gradient_square = self.delta_t[idx]**2
-                self.v_t[idx] = self.v_t[idx] - (1.-self.beta2) * gradient_square * torch.sign(
-                    self.v_t[idx] - gradient_square)
-                yogi_learning_rate = self.eta / \
-                    (torch.sqrt(self.v_t[idx]) + self.tau)
+            
+            self.m_t[idx] = self.beta * \
+                self.m_t[idx] + (1.-self.beta) * gradient
+ 
+            self.v_t[idx] = self.v_t[idx] - (1.-self.beta2) * gradient_square * torch.sign(
+                self.v_t[idx] - gradient_square)
+            yogi_learning_rate = self.eta / \
+                (torch.sqrt(self.v_t[idx]) + self.tau)
 
-                update_gradients.append(yogi_learning_rate * self.delta_t[idx])
+            update_gradients.append(yogi_learning_rate * self.m_t[idx])
 
         if len(update_gradients) == 0:
             update_gradients = gradients

--- a/fedscale/utils/optimizer/yogi.py
+++ b/fedscale/utils/optimizer/yogi.py
@@ -15,8 +15,8 @@ class YoGi:
     def update(self, gradients):
         update_gradients = []
         if not self.v_t:
-            self.v_t = [np.full(len(g), self.tau**2, dtype=np.float32) for g in gradients]
-            self.m_t = [np.full(len(g), 0.0, dtype=np.float32) for g in gradients]
+            self.v_t = [torch.full_like(g, self.tau**2) for g in gradients]
+            self.m_t = [torch.full_like(g, 0.0) for g in gradients]
 
         for idx, gradient in enumerate(gradients):
             gradient_square = gradient**2

--- a/fedscale/utils/optimizer/yogi.py
+++ b/fedscale/utils/optimizer/yogi.py
@@ -15,7 +15,7 @@ class YoGi:
     def update(self, gradients):
         update_gradients = []
         if not self.v_t:
-            self.v_t = [g**2 for g in gradients]
+            self.v_t = [torch.full_like(g, self.tau) for g in gradients]
             self.m_t = [torch.full_like(g, 0.0) for g in gradients]
 
         for idx, gradient in enumerate(gradients):


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
@fanlai0990 
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
There is a bug when executor pulls the model from the aggregator. In original implementation, the model adapter will execute the optimizer step at the executor, which should theoretically be executed only at the aggregator end, leading to poor performance for fed-yogi.
What I did:
1. Turn off optimizer step at the executor
2. Edit `gradient_policy` (optimizer) naming in several config files, from `yogi` to `fed-yogi`. If use `yogi`, the real optimizer would be `fed-avg` as if statement for `fed-yogi` in optimizer is not entered.
3. Change initial hyperparameter weight of `fed-yogi` according to the fed-yogi paper. Original setup might cause the model to drift a little bit before starting to converge
   ```python
            self.v_t = [torch.full_like(g, self.tau) for g in gradients]
            self.m_t = [torch.full_like(g, 0.0) for g in gradients]
   ```

## Related issue number
#243
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://fedscale.readthedocs.io/en/latest/
- [x] I've made sure the following tests are passing.
- Testing Configurations
   - [x] Dry Run (20 training rounds & 1 evaluation round)
   - [x] Cifar 10 (20 training rounds & 1 evaluation round)
   - [x] Femnist (20 training rounds & 1 evaluation round)
 
## FEMNIST fed-yogi optimizer run result
![Screenshot from 2023-12-17 08-17-44](https://github.com/SymbioticLab/FedScale/assets/70790160/937ad71b-cb9a-46c3-80e8-9d64399ea963)
![Screenshot from 2023-12-17 08-17-49](https://github.com/SymbioticLab/FedScale/assets/70790160/98868b4a-88df-41bf-98c2-5fd3d2e76376)